### PR TITLE
ADD HTTP HEADERS TO EXTRACTIONS: As Dan, I want to be able to add http headers to an extraction definition, so that I can work with NLNZcat and others

### DIFF
--- a/app/controllers/extraction_definitions_controller.rb
+++ b/app/controllers/extraction_definitions_controller.rb
@@ -15,10 +15,6 @@ class ExtractionDefinitionsController < ApplicationController
 
   def new
     @extraction_definition = ExtractionDefinition.new(kind: params[:kind])
-
-    3.times do
-      @extraction_definition.headers.new
-    end
   end
 
   def edit; end

--- a/app/controllers/extraction_definitions_controller.rb
+++ b/app/controllers/extraction_definitions_controller.rb
@@ -15,6 +15,10 @@ class ExtractionDefinitionsController < ApplicationController
 
   def new
     @extraction_definition = ExtractionDefinition.new(kind: params[:kind])
+
+    3.times do
+      @extraction_definition.headers.new
+    end
   end
 
   def edit; end
@@ -101,7 +105,8 @@ class ExtractionDefinitionsController < ApplicationController
       :page_parameter, :per_page_parameter, :page, :per_page,
       :total_selector,
       :kind, :destination_id, :source_id, :enrichment_url, :job_id,
-      :token_parameter, :token_value, :next_token_path, :initial_params
+      :token_parameter, :token_value, :next_token_path, :initial_params,
+      headers_attributes: [:id, :name, :value]
     )
   end
 end

--- a/app/controllers/extraction_definitions_controller.rb
+++ b/app/controllers/extraction_definitions_controller.rb
@@ -51,7 +51,11 @@ class ExtractionDefinitionsController < ApplicationController
   end
 
   def test
-    @extraction_definition = ExtractionDefinition.new(extraction_definition_params)
+    @extraction_definition = ExtractionDefinition.new(extraction_definition_params.except('headers_attributes'))
+
+    extraction_definition_params['headers_attributes'].each do |key, header_attributes|
+      @extraction_definition.headers << Header.new(header_attributes)
+    end
 
     render json: Extraction::DocumentExtraction.new(@extraction_definition).extract
   end

--- a/app/frontend/js/ExtractionDefinitionFormLogic.js
+++ b/app/frontend/js/ExtractionDefinitionFormLogic.js
@@ -33,6 +33,52 @@ if(extractionDefinitionPaginationTypeSelect) {
       element.style.display = 'none';
     });
   }
+
+  const extractionDefinitionAddHeader = document.getElementById('js-extraction-definition-add-header');
+
+  if(extractionDefinitionAddHeader) {
+    extractionDefinitionAddHeader.addEventListener('click', (event) => {
+
+      const formElements = document.querySelector('#js-extraction-definition-headers').getElementsByClassName('form-control');
+      const lastElement = formElements[formElements.length - 1];
+      let newId;
+
+      if(lastElement != undefined) {
+        const lastId = lastElement.id.match(/.+(?<id>\d)/).groups.id;
+        newId = parseInt(lastId) + 1;
+      } else {
+        newId = 0;
+      }
+
+      const headerForm = `
+        <div class='row gy-3 mb-5 align-items-center'>
+          <div class='col-4'>
+            <label class='form-label' for='extraction_definition_headers_attributes_${newId}_name'>
+              Header Name
+            </label>                
+          </div>
+          
+          <div class='col-8'>
+            <input class='form-control' type='text' name='extraction_definition[headers_attributes][${newId}][name]'' id='extraction_definition_headers_attributes_${newId}_name'>
+          </div>
+          
+          <div class='col-4'>
+            <label class='form-label' for='extraction_definition_headers_attributes_${newId}_value'>
+              Header Value
+            </label>                
+          </div>
+        
+          <div class='col-8'>
+            <input class='form-control' type='text' name='extraction_definition[headers_attributes][${newId}][value]'' id='extraction_definition_headers_attributes_${newId}_value'>
+          </div>
+        </div>
+      `;
+
+      document.getElementById('js-extraction-definition-headers')
+        .insertAdjacentHTML('beforeend', headerForm);
+
+    });
+  }
 }
 
 

--- a/app/models/extraction_definition.rb
+++ b/app/models/extraction_definition.rb
@@ -3,6 +3,8 @@
 # Used to store the information for running an extraction
 #
 class ExtractionDefinition < ApplicationRecord
+  serialize :headers, Array
+
   scope :originals, -> { where(original_extraction_definition: nil) }
 
   belongs_to :content_source

--- a/app/models/extraction_definition.rb
+++ b/app/models/extraction_definition.rb
@@ -3,13 +3,13 @@
 # Used to store the information for running an extraction
 #
 class ExtractionDefinition < ApplicationRecord
-  serialize :headers, Array
-
   scope :originals, -> { where(original_extraction_definition: nil) }
 
   belongs_to :content_source
-  has_many :extraction_jobs
   belongs_to :destination, optional: true
+  
+  has_many :extraction_jobs
+  has_many :headers
 
   enum :kind, { harvest: 0, enrichment: 1 }
 

--- a/app/models/extraction_definition.rb
+++ b/app/models/extraction_definition.rb
@@ -13,6 +13,8 @@ class ExtractionDefinition < ApplicationRecord
 
   enum :kind, { harvest: 0, enrichment: 1 }
 
+  accepts_nested_attributes_for :headers
+
   after_create do
     self.name = "#{content_source.name.parameterize}__#{kind}-extraction-#{id}"
     save!

--- a/app/models/header.rb
+++ b/app/models/header.rb
@@ -5,4 +5,10 @@ class Header < ApplicationRecord
   
   validates :name, presence: true
   validates :value, presence: true
+
+  def to_h
+    {
+      name => value
+    }
+  end
 end

--- a/app/models/header.rb
+++ b/app/models/header.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class Header < ApplicationRecord
+  belongs_to :extraction_definition
+  
+  validates :name, presence: true
+  validates :value, presence: true
+end

--- a/app/supplejack/extraction/document_extraction.rb
+++ b/app/supplejack/extraction/document_extraction.rb
@@ -35,6 +35,13 @@ module Extraction
         )
     end
 
+    def headers
+      super
+        .merge(
+          @extraction_definition.headers.map(&:to_h).reduce(&:merge)
+        )
+    end
+
     # There are scenarios where a harvester adds a string of additional params
     # that are only used on the very first API call to the Content Source.
     # These params can actually break subsequent calls if they are added where they are not expected to be.

--- a/app/views/extraction_definitions/_harvest_form.html.erb
+++ b/app/views/extraction_definitions/_harvest_form.html.erb
@@ -8,7 +8,6 @@
           <legend>Common settings</legend>
 
           <div class="row gy-3 align-items-center">
-
             <% if @extraction_definition.name.present? %>
               <div class="col-3">
                 <%= form.label :name, 'Name', class: "form-label" %>
@@ -49,7 +48,6 @@
         </div>
       </div>
     </fieldset>
-
 
     <fieldset class="col-6">
       <div class="card">
@@ -166,36 +164,40 @@
       </div>
     </fieldset>
     
-    <fieldset class="col-12 my-4">
+    <fieldset class="col-12 my-4" >
       <div class="card">
-        <div class="card-body">
+        <div class="card-body"> 
           <legend>Headers</legend>
 
-          <%= form.fields_for :headers do |header_form| %>
-
-            <div class="row gy-3 mb-5 align-items-center">
-              <div class="col-4">
-                <%= header_form.label :name, class: "form-label" do %>
-                  Header Name
-                <% end %>
-              </div>
+          <span id='js-extraction-definition-headers'>
+            <%= form.fields_for :headers do |header_form| %>
+              <div class="row gy-3 mb-5 align-items-center">
+                <div class="col-4">
+                  <%= header_form.label :name, class: "form-label" do %>
+                    Header Name
+                  <% end %>
+                </div>
             
-              <div class="col-8">
-                <%= header_form.text_field :name, class: "form-control" %>
-              </div>
+                <div class="col-8">
+                  <%= header_form.text_field :name, class: "form-control" %>
+                </div>
               
-              <div class="col-4">
-                <%= header_form.label :value, class: "form-label" do %>
-                  Header Value
-                <% end %>
-              </div>
+                <div class="col-4">
+                  <%= header_form.label :value, class: "form-label" do %>
+                    Header Value
+                  <% end %>
+                </div>
             
-              <div class="col-8">
-                <%= header_form.text_field :value, class: "form-control" %>
+                <div class="col-8">
+                  <%= header_form.text_field :value, class: "form-control" %>
+                </div>
               </div>
-            </div>
-           
-          <% end %>
+            <% end %>
+          </span>
+
+          <button class="btn btn-primary float-end" id="js-extraction-definition-add-header" type="button" aria-selected="true">
+            Add header
+          </button>
         </div>
       </div>
     </fieldset>

--- a/app/views/extraction_definitions/_harvest_form.html.erb
+++ b/app/views/extraction_definitions/_harvest_form.html.erb
@@ -50,6 +50,7 @@
       </div>
     </fieldset>
 
+
     <fieldset class="col-6">
       <div class="card">
         <div class="card-body">
@@ -160,6 +161,30 @@
               <%= form.number_field :per_page, class: "form-control" %>
             </div>
 
+          </div>
+        </div>
+      </div>
+    </fieldset>
+    
+    <fieldset class="col-12 my-4">
+      <div class="card">
+        <div class="card-body">
+          <legend>Headers</legend>
+
+          <div class="row gy-3 align-items-center">
+            <div class="col-3">
+              <%= form.label :header_name, 'Name', class: "form-label" %>
+            </div>
+            <div class="col-9">
+              <%= form.text_field :header_name, class: "form-control" %>
+            </div>
+
+            <div class="col-3">
+              <%= form.label :header_value, 'Value', class: "form-label" %>
+            </div>
+            <div class="col-9">
+              <%= form.text_field :header_value, class: "form-control" %>
+            </div>
           </div>
         </div>
       </div>

--- a/app/views/extraction_definitions/_harvest_form.html.erb
+++ b/app/views/extraction_definitions/_harvest_form.html.erb
@@ -171,21 +171,31 @@
         <div class="card-body">
           <legend>Headers</legend>
 
-          <div class="row gy-3 align-items-center">
-            <div class="col-3">
-              <%= form.label :header_name, 'Name', class: "form-label" %>
-            </div>
-            <div class="col-9">
-              <%= form.text_field :header_name, class: "form-control" %>
-            </div>
+          <%= form.fields_for :headers do |header_form| %>
 
-            <div class="col-3">
-              <%= form.label :header_value, 'Value', class: "form-label" %>
+            <div class="row gy-3 mb-5 align-items-center">
+              <div class="col-4">
+                <%= header_form.label :name, class: "form-label" do %>
+                  Header Name
+                <% end %>
+              </div>
+            
+              <div class="col-8">
+                <%= header_form.text_field :name, class: "form-control" %>
+              </div>
+              
+              <div class="col-4">
+                <%= header_form.label :value, class: "form-label" do %>
+                  Header Value
+                <% end %>
+              </div>
+            
+              <div class="col-8">
+                <%= header_form.text_field :value, class: "form-control" %>
+              </div>
             </div>
-            <div class="col-9">
-              <%= form.text_field :header_value, class: "form-control" %>
-            </div>
-          </div>
+           
+          <% end %>
         </div>
       </div>
     </fieldset>

--- a/db/migrate/20230629015749_add_headers_to_extraction_definition.rb
+++ b/db/migrate/20230629015749_add_headers_to_extraction_definition.rb
@@ -1,0 +1,5 @@
+class AddHeadersToExtractionDefinition < ActiveRecord::Migration[7.0]
+  def change
+    add_column :extraction_definitions, :headers, :text
+  end
+end

--- a/db/migrate/20230629015749_add_headers_to_extraction_definition.rb
+++ b/db/migrate/20230629015749_add_headers_to_extraction_definition.rb
@@ -1,5 +1,0 @@
-class AddHeadersToExtractionDefinition < ActiveRecord::Migration[7.0]
-  def change
-    add_column :extraction_definitions, :headers, :text
-  end
-end

--- a/db/migrate/20230629204141_create_headers.rb
+++ b/db/migrate/20230629204141_create_headers.rb
@@ -1,0 +1,12 @@
+class CreateHeaders < ActiveRecord::Migration[7.0]
+  def change
+    create_table :headers do |t|
+      t.string :name
+      t.string :value
+
+      t.timestamps
+    end
+
+    add_reference :headers, :extraction_definition, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_29_015749) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_26_010755) do
   create_table "content_sources", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
     t.datetime "created_at", null: false
@@ -49,7 +49,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_29_015749) do
     t.string "token_parameter"
     t.string "token_value"
     t.string "initial_params"
-    t.text "headers"
     t.index ["content_source_id"], name: "index_extraction_definitions_on_content_source_id"
     t.index ["destination_id"], name: "index_extraction_definitions_on_destination_id"
     t.index ["original_extraction_definition_id"], name: "index_eds_on_original_ed_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_26_010755) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_29_015749) do
   create_table "content_sources", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
     t.datetime "created_at", null: false
@@ -49,6 +49,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_26_010755) do
     t.string "token_parameter"
     t.string "token_value"
     t.string "initial_params"
+    t.text "headers"
     t.index ["content_source_id"], name: "index_extraction_definitions_on_content_source_id"
     t.index ["destination_id"], name: "index_extraction_definitions_on_destination_id"
     t.index ["original_extraction_definition_id"], name: "index_eds_on_original_ed_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_26_010755) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_29_204141) do
   create_table "content_sources", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
     t.datetime "created_at", null: false
@@ -107,6 +107,15 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_26_010755) do
     t.text "name"
     t.index ["extraction_job_id"], name: "index_harvest_jobs_on_extraction_job_id"
     t.index ["harvest_definition_id"], name: "index_harvest_jobs_on_harvest_definition_id"
+  end
+
+  create_table "headers", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "name"
+    t.string "value"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "extraction_definition_id", null: false
+    t.index ["extraction_definition_id"], name: "index_headers_on_extraction_definition_id"
   end
 
   create_table "load_jobs", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|

--- a/spec/factories/header.rb
+++ b/spec/factories/header.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+FactoryBot.define do 
+  factory :header do
+    name { 'x-forwarded-for' }
+    value { 'ab.cd.ef.gh' }
+
+    association :extraction_definition
+  end
+end
+

--- a/spec/models/extraction_definition_spec.rb
+++ b/spec/models/extraction_definition_spec.rb
@@ -40,6 +40,18 @@ RSpec.describe ExtractionDefinition, type: :model do
     end
   end
 
+  describe '#headers' do
+    subject! { create(:extraction_definition, headers: [{ 'X-Forwarded-For' => 'ab.cd.ef.gh' }, { 'Authorization' => 'BLAH' }, { 'x-api-key' => 'key' }])}
+
+    it 'can have many headers associated with it' do
+      expect(subject.headers.count).to eq 3
+
+      expect(subject.headers[0]['X-Forwarded-For']).to eq 'ab.cd.ef.gh'
+      expect(subject.headers[1]['Authorization']).to eq 'BLAH'
+      expect(subject.headers[2]['x-api-key']).to eq 'key'
+    end
+  end
+
   describe '#validation numericality' do
     it do
       expect(subject).to validate_numericality_of(:throttle)

--- a/spec/models/extraction_definition_spec.rb
+++ b/spec/models/extraction_definition_spec.rb
@@ -40,18 +40,6 @@ RSpec.describe ExtractionDefinition, type: :model do
     end
   end
 
-  describe '#headers' do
-    subject! { create(:extraction_definition, headers: [{ 'X-Forwarded-For' => 'ab.cd.ef.gh' }, { 'Authorization' => 'BLAH' }, { 'x-api-key' => 'key' }])}
-
-    it 'can have many headers associated with it' do
-      expect(subject.headers.count).to eq 3
-
-      expect(subject.headers[0]['X-Forwarded-For']).to eq 'ab.cd.ef.gh'
-      expect(subject.headers[1]['Authorization']).to eq 'BLAH'
-      expect(subject.headers[2]['x-api-key']).to eq 'key'
-    end
-  end
-
   describe '#validation numericality' do
     it do
       expect(subject).to validate_numericality_of(:throttle)
@@ -109,14 +97,19 @@ RSpec.describe ExtractionDefinition, type: :model do
 
   describe '#associations' do
     let(:extraction_job) { create(:extraction_job) }
-    let(:ed) { create(:extraction_definition, extraction_jobs: [extraction_job]) }
+    let(:header)         { create(:header) }
+    subject { create(:extraction_definition, extraction_jobs: [extraction_job], headers: [header]) }
 
     it 'has many jobs' do
-      expect(ed.extraction_jobs).to include extraction_job
+      expect(subject.extraction_jobs).to include(extraction_job)
     end
 
     it 'belongs to a content source' do
       expect(subject.content_source).to be_a ContentSource
+    end
+
+    it 'has many headers' do
+      expect(subject.headers).to include(header)
     end
   end
 

--- a/spec/models/header_spec.rb
+++ b/spec/models/header_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe Header, type: :model do
+  let(:extraction_definition) { create(:extraction_definition) }
+  subject { create(:header, extraction_definition:) }
+
+  describe 'validations' do
+    subject { build(:header) }
+
+    it { is_expected.to validate_presence_of(:name) }
+    it { is_expected.to validate_presence_of(:value) }
+  end
+
+  describe 'associations' do
+    it 'belongs to an extraction_definition' do
+      expect(subject.extraction_definition).to eq extraction_definition
+    end
+  end
+end

--- a/spec/models/header_spec.rb
+++ b/spec/models/header_spec.rb
@@ -12,8 +12,6 @@ RSpec.describe Header, type: :model do
   end
 
   describe 'associations' do
-    it 'belongs to an extraction_definition' do
-      expect(subject.extraction_definition).to eq extraction_definition
-    end
+    it { is_expected.to belong_to(:extraction_definition) }
   end
 end

--- a/spec/requests/extraction_definitions_spec.rb
+++ b/spec/requests/extraction_definitions_spec.rb
@@ -53,6 +53,23 @@ RSpec.describe 'ExtractionDefinitions', type: :request do
 
         expect(response).to redirect_to content_source_path(content_source)
       end
+
+      it 'creates a new extraction definition with associated headers' do
+        extraction_definition2 = build(:extraction_definition, content_source:)
+        headers = build_list(:header, 2)
+
+        post content_source_extraction_definitions_path(content_source), params: {
+          extraction_definition: extraction_definition2.attributes.merge('headers_attributes' => headers.map(&:attributes))
+        }
+
+        ed = ExtractionDefinition.last
+
+        expect(ed.headers.first.name).to eq headers.first.name
+        expect(ed.headers.first.value).to eq headers.first.value
+
+        expect(ed.headers.last.name).to eq headers.last.name
+        expect(ed.headers.last.value).to eq headers.last.value
+      end
     end
 
     context 'with invalid parameters' do


### PR DESCRIPTION
**Acceptance Criteria**
- Extractions can be configured to use things like:
 - `http_headers({'X-Forwarded-For': 'ab.cd.ef.gh'})` 
 - `http_headers({'Authorization': 'Bearer BLAAAAAAH'})` 
 - `http_headers({'Authorization': 'Basic BLAAAAAAAH'})` 
 - `http_headers({'x-api-key': 'asdsads'})`
 - 
- Allow multiple headers to be added

**Risks**
- ?

