### PR TITLE
MOVE THROUGH PREVIEW RECORDS: As Ting, I want to be able to navigate through my extracted records, so that I can see how my transformations work on other records

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,7 @@
 class ApplicationController < ActionController::Base
   include UserAuthorization
   include DeviseOverrides
+  include ReduxState
 
   def paginate_and_filter_jobs(jobs)
     @status = params[:status]

--- a/app/controllers/concerns/redux_state.rb
+++ b/app/controllers/concerns/redux_state.rb
@@ -25,16 +25,7 @@ module ReduxState
   end
 
   def raw_record_slice
-    records = @transformation_definition.records
-    record_number = (params[:record] || 1).to_i
-    {
-      page: (params[:page] || 1).to_i,
-      record: record_number,
-      totalPages: @transformation_definition.extraction_job.documents.total_pages,
-      totalRecords: records.length,
-      format: @transformation_definition.extraction_job.format,
-      body: records[record_number]
-    }
+    RawRecordSlice.new(@transformation_definition, params[:page], params[:record]).call
   end
 
   def app_details_slice

--- a/app/controllers/concerns/redux_state.rb
+++ b/app/controllers/concerns/redux_state.rb
@@ -30,8 +30,8 @@ module ReduxState
     {
       page: (params[:page] || 1).to_i,
       record: record_number,
-      total_pages: @transformation_definition.extraction_job.documents.total_pages,
-      total_records: records.length,
+      totalPages: @transformation_definition.extraction_job.documents.total_pages,
+      totalRecords: records.length,
       format: @transformation_definition.extraction_job.format,
       body: records[record_number]
     }

--- a/app/controllers/concerns/redux_state.rb
+++ b/app/controllers/concerns/redux_state.rb
@@ -6,7 +6,7 @@ module ReduxState
   def transformation_app_state
     {
       entities: {
-        fields: fields_slice, appDetails: app_details_slice
+        fields: fields_slice, rawRecord: raw_record_slice, appDetails: app_details_slice
       },
       ui: {
         fields: ui_fields_slice, appDetails: ui_app_details_slice
@@ -24,10 +24,21 @@ module ReduxState
     }
   end
 
+  def raw_record_slice
+    records = @transformation_definition.records
+    record_number = (params[:record] || 1).to_i
+    {
+      page: (params[:page] || 1).to_i,
+      record: record_number,
+      total_pages: @transformation_definition.extraction_job.documents.total_pages,
+      total_records: records.length,
+      format: @transformation_definition.extraction_job.format,
+      body: records[record_number]
+    }
+  end
+
   def app_details_slice
     {
-      format: @transformation_definition.extraction_job.format,
-      rawRecord: @transformation_definition.records.first,
       transformedRecord: {},
       contentSource: @content_source,
       transformationDefinition: @transformation_definition

--- a/app/controllers/concerns/redux_state.rb
+++ b/app/controllers/concerns/redux_state.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+module ReduxState
+  extend ActiveSupport::Concern
+
+  def transformation_app_state
+    {
+      entities: {
+        fields: fields_slice, appDetails: app_details_slice
+      },
+      ui: {
+        fields: ui_fields_slice, appDetails: ui_app_details_slice
+      },
+      config: config_slice
+    }.to_json
+  end
+
+  private
+
+  def fields_slice
+    {
+      ids: @transformation_definition.fields.map(&:id),
+      entities: @fields.index_by { |field| field[:id] }
+    }
+  end
+
+  def app_details_slice
+    {
+      format: @transformation_definition.extraction_job.format,
+      rawRecord: @transformation_definition.records.first,
+      transformedRecord: {},
+      contentSource: @content_source,
+      transformationDefinition: @transformation_definition
+    }
+  end
+
+  def ui_fields_slice
+    field_entities = @fields.map { |field| ui_field_entity(field) }
+    {
+      ids: @transformation_definition.fields.map(&:id),
+      entities: field_entities.index_by { |field| field[:id] }
+    }
+  end
+
+  def ui_field_entity(field)
+    {
+      id: field[:id],
+      saved: true, saving: false,
+      deleting: false,
+      running: false,
+      hasRun: false,
+      expanded: true,
+      displayed: false
+    }
+  end
+
+  def ui_app_details_slice
+    {
+      fieldNavExpanded: true,
+      rawRecordExpanded: true,
+      transformedRecordExpanded: true,
+      readOnly: @transformation_definition.copy?
+    }
+  end
+
+  def config_slice
+    {
+      environment: Rails.env
+    }
+  end
+end

--- a/app/controllers/raw_records_controller.rb
+++ b/app/controllers/raw_records_controller.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class RawRecordsController < ApplicationController
+  def index
+    transformation_definition = TransformationDefinition.find(params[:transformation_definition_id])
+
+    render json: RawRecordSlice.new(transformation_definition, params[:page], params[:record]).call
+  end
+end

--- a/app/controllers/transformation_definitions_controller.rb
+++ b/app/controllers/transformation_definitions_controller.rb
@@ -12,47 +12,7 @@ class TransformationDefinitionsController < ApplicationController
       HarvestDefinition.find_by(transformation_definition_id: copy.id)
     end.compact
 
-    @props = {
-      entities: {
-        fields: {
-          ids: @transformation_definition.fields.map(&:id),
-          entities: @fields.index_by { |field| field[:id] }
-        },
-        appDetails: {
-          format: @transformation_definition.extraction_job.format,
-          rawRecord: @transformation_definition.records.first,
-          transformedRecord: {},
-          contentSource: @content_source,
-          transformationDefinition: @transformation_definition
-        }
-      },
-      ui: {
-        fields: {
-          ids: @transformation_definition.fields.map(&:id),
-          entities: @fields.map.with_index do |field, index|
-            {
-              id: field[:id],
-              saved: true,
-              deleting: false,
-              saving: false,
-              running: false,
-              hasRun: false,
-              expanded: true,
-              displayed: false
-            }
-          end.index_by { |field| field[:id] }
-        },
-        appDetails: {
-          fieldNavExpanded: true,
-          rawRecordExpanded: true,
-          transformedRecordExpanded: true,
-          readOnly: @transformation_definition.copy?
-        }
-      },
-      config: {
-        environment: Rails.env
-      }
-    }.to_json
+    @props = transformation_app_state
   end
 
   def new

--- a/app/frontend/entrypoints/application.scss
+++ b/app/frontend/entrypoints/application.scss
@@ -26,6 +26,7 @@
 @import "../stylesheets/blocks/field-nav-panel";
 @import "../stylesheets/blocks/form-in-dropdown";
 @import "../stylesheets/blocks/header";
+@import "../stylesheets/blocks/jump-to";
 @import "../stylesheets/blocks/record-view";
 
 

--- a/app/frontend/js/apps/TransformationApp/JumpTo.jsx
+++ b/app/frontend/js/apps/TransformationApp/JumpTo.jsx
@@ -1,0 +1,71 @@
+import React from "react";
+
+const JumpTo = () => {
+  return (
+    <div className="dropdown jump-to">
+      <button
+        className="btn btn-primary dropdown-toggle text-truncate"
+        type="button"
+        data-bs-toggle="dropdown"
+        data-bs-auto-close="outside"
+        aria-expanded="false"
+      >
+        Jump to
+      </button>
+      <div className="dropdown-menu dropdown-menu-end jump-to__body p-2">
+        <div class="row gx-1 mb-3">
+          <label className="col-4 col-form-label" htmlFor="page">
+            Page
+          </label>
+          <div className="col">
+            <div className="input-group">
+              <input
+                name="page"
+                id="page"
+                className="form-control jump-to__input"
+                type="number"
+                value="1"
+              />{" "}
+              <span className="input-group-text">/ 50</span>
+            </div>
+          </div>
+          <div className="col-auto">
+            <button className="btn btn-primary">Go</button>
+          </div>
+        </div>
+        <div class="row gx-1 mb-3">
+          <label className="col-4 col-form-label" htmlFor="record">
+            Record
+          </label>
+          <div className="col">
+            <div className="mr-2">
+              <div className="input-group">
+                <input
+                  name="record"
+                  id="record"
+                  className="form-control jump-to__input"
+                  type="number"
+                  value="1"
+                />
+                <span className="input-group-text"> / 50</span>
+              </div>
+            </div>
+          </div>
+          <div className="col-auto">
+            <button className="btn btn-primary">Go</button>
+          </div>
+        </div>
+        <div
+          className="btn-group-vertical w-100"
+          role="group"
+          aria-label="Quick navigation"
+        >
+          <button className="btn btn-outline-primary">Previous</button>
+          <button className="btn btn-outline-primary">Next</button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default JumpTo;

--- a/app/frontend/js/apps/TransformationApp/JumpTo.jsx
+++ b/app/frontend/js/apps/TransformationApp/JumpTo.jsx
@@ -15,7 +15,6 @@ const JumpTo = () => {
   const [inputRecord, setInputRecord] = useState(record);
 
   useEffect(() => {
-    console.log("ehllo");
     setInputPage(page);
     setInputRecord(record);
   }, [page, record]);

--- a/app/frontend/js/apps/TransformationApp/JumpTo.jsx
+++ b/app/frontend/js/apps/TransformationApp/JumpTo.jsx
@@ -1,13 +1,55 @@
-import React, { useState } from "react";
-import { useSelector } from "react-redux";
-import { selectRawRecord } from "/js/features/RawRecordSlice";
+import React, { useEffect, useState } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { askNewRawRecord, selectRawRecord } from "/js/features/RawRecordSlice";
+import { selectAppDetails } from "/js/features/AppDetailsSlice";
 
 const JumpTo = () => {
-  const { page, record, totalPages, totalRecords } =
+  const dispatch = useDispatch();
+
+  const { transformationDefinition } = useSelector(selectAppDetails);
+
+  const { isFetching, page, record, totalPages, totalRecords } =
     useSelector(selectRawRecord);
 
   const [inputPage, setInputPage] = useState(page);
   const [inputRecord, setInputRecord] = useState(record);
+
+  useEffect(() => {
+    console.log("ehllo");
+    setInputPage(page);
+    setInputRecord(record);
+  }, [page, record]);
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    dispatch(
+      askNewRawRecord({
+        transformationDefinitionId: transformationDefinition.id,
+        page: inputPage,
+        record: inputRecord,
+      })
+    );
+  };
+
+  const handleNextRecordClick = (e) => {
+    dispatch(
+      askNewRawRecord({
+        transformationDefinitionId: transformationDefinition.id,
+        page: record === totalRecords ? page + 1 : page,
+        record: record === totalRecords ? 1 : record + 1,
+      })
+    );
+  };
+
+  const handlePreviousRecordClick = (e) => {
+    dispatch(
+      askNewRawRecord({
+        transformationDefinitionId: transformationDefinition.id,
+        page: record === 1 ? page - 1 : page,
+        record: record === 1 ? totalRecords : record - 1,
+      })
+    );
+  };
 
   return (
     <div className="dropdown jump-to">
@@ -21,8 +63,8 @@ const JumpTo = () => {
         Jump to
       </button>
       <div className="dropdown-menu dropdown-menu-end jump-to__body p-2">
-        <div className="row gx-1 mb-3">
-          <label className="col-4 col-form-label" htmlFor="page">
+        <form className="row gx-1 mb-3" onSubmit={handleSubmit}>
+          <label className="col-3 col-form-label" htmlFor="page">
             Page
           </label>
           <div className="col">
@@ -31,9 +73,10 @@ const JumpTo = () => {
                 name="page"
                 id="page"
                 className="form-control"
+                disabled={isFetching || record !== inputRecord}
                 type="number"
                 value={inputPage}
-                onChange={(e) => setInputPage(e.target.value)}
+                onChange={(e) => setInputPage(parseInt(e.target.value))}
               />
               <span className="input-group-text">/ {totalPages}</span>
             </div>
@@ -42,6 +85,7 @@ const JumpTo = () => {
             <button
               className="btn btn-primary"
               disabled={
+                isFetching ||
                 record !== inputRecord ||
                 page === inputPage ||
                 inputPage > totalPages
@@ -50,9 +94,9 @@ const JumpTo = () => {
               Go
             </button>
           </div>
-        </div>
-        <div className="row gx-1 mb-3">
-          <label className="col-4 col-form-label" htmlFor="record">
+        </form>
+        <form className="row gx-1 mb-3" onSubmit={handleSubmit}>
+          <label className="col-3 col-form-label" htmlFor="record">
             Record
           </label>
           <div className="col">
@@ -62,9 +106,10 @@ const JumpTo = () => {
                   name="record"
                   id="record"
                   className="form-control"
+                  disabled={isFetching || page !== inputPage}
                   type="number"
                   value={inputRecord}
-                  onChange={(e) => setInputRecord(e.target.value)}
+                  onChange={(e) => setInputRecord(parseInt(e.target.value))}
                 />
                 <span className="input-group-text"> / {totalRecords}</span>
               </div>
@@ -74,6 +119,7 @@ const JumpTo = () => {
             <button
               className="btn btn-primary"
               disabled={
+                isFetching ||
                 page !== inputPage ||
                 record === inputRecord ||
                 inputRecord > totalRecords
@@ -82,7 +128,7 @@ const JumpTo = () => {
               Go
             </button>
           </div>
-        </div>
+        </form>
         <div
           className="btn-group-vertical w-100"
           role="group"
@@ -90,13 +136,17 @@ const JumpTo = () => {
         >
           <button
             className="btn btn-outline-primary"
-            disabled={page == 1 && record == 1}
+            disabled={isFetching || (page == 1 && record == 1)}
+            onClick={handlePreviousRecordClick}
           >
             Previous record
           </button>
           <button
             className="btn btn-outline-primary"
-            disabled={page == totalPages && record == totalRecords}
+            disabled={
+              isFetching || (page == totalPages && record == totalRecords)
+            }
+            onClick={handleNextRecordClick}
           >
             Next record
           </button>

--- a/app/frontend/js/apps/TransformationApp/JumpTo.jsx
+++ b/app/frontend/js/apps/TransformationApp/JumpTo.jsx
@@ -1,6 +1,14 @@
-import React from "react";
+import React, { useState } from "react";
+import { useSelector } from "react-redux";
+import { selectRawRecord } from "/js/features/RawRecordSlice";
 
 const JumpTo = () => {
+  const { page, record, totalPages, totalRecords } =
+    useSelector(selectRawRecord);
+
+  const [inputPage, setInputPage] = useState(page);
+  const [inputRecord, setInputRecord] = useState(record);
+
   return (
     <div className="dropdown jump-to">
       <button
@@ -13,7 +21,7 @@ const JumpTo = () => {
         Jump to
       </button>
       <div className="dropdown-menu dropdown-menu-end jump-to__body p-2">
-        <div class="row gx-1 mb-3">
+        <div className="row gx-1 mb-3">
           <label className="col-4 col-form-label" htmlFor="page">
             Page
           </label>
@@ -22,18 +30,28 @@ const JumpTo = () => {
               <input
                 name="page"
                 id="page"
-                className="form-control jump-to__input"
+                className="form-control"
                 type="number"
-                value="1"
-              />{" "}
-              <span className="input-group-text">/ 50</span>
+                value={inputPage}
+                onChange={(e) => setInputPage(e.target.value)}
+              />
+              <span className="input-group-text">/ {totalPages}</span>
             </div>
           </div>
           <div className="col-auto">
-            <button className="btn btn-primary">Go</button>
+            <button
+              className="btn btn-primary"
+              disabled={
+                record !== inputRecord ||
+                page === inputPage ||
+                inputPage > totalPages
+              }
+            >
+              Go
+            </button>
           </div>
         </div>
-        <div class="row gx-1 mb-3">
+        <div className="row gx-1 mb-3">
           <label className="col-4 col-form-label" htmlFor="record">
             Record
           </label>
@@ -43,16 +61,26 @@ const JumpTo = () => {
                 <input
                   name="record"
                   id="record"
-                  className="form-control jump-to__input"
+                  className="form-control"
                   type="number"
-                  value="1"
+                  value={inputRecord}
+                  onChange={(e) => setInputRecord(e.target.value)}
                 />
-                <span className="input-group-text"> / 50</span>
+                <span className="input-group-text"> / {totalRecords}</span>
               </div>
             </div>
           </div>
           <div className="col-auto">
-            <button className="btn btn-primary">Go</button>
+            <button
+              className="btn btn-primary"
+              disabled={
+                page !== inputPage ||
+                record === inputRecord ||
+                inputRecord > totalRecords
+              }
+            >
+              Go
+            </button>
           </div>
         </div>
         <div
@@ -60,8 +88,18 @@ const JumpTo = () => {
           role="group"
           aria-label="Quick navigation"
         >
-          <button className="btn btn-outline-primary">Previous</button>
-          <button className="btn btn-outline-primary">Next</button>
+          <button
+            className="btn btn-outline-primary"
+            disabled={page == 1 && record == 1}
+          >
+            Previous record
+          </button>
+          <button
+            className="btn btn-outline-primary"
+            disabled={page == totalPages && record == totalRecords}
+          >
+            Next record
+          </button>
         </div>
       </div>
     </div>

--- a/app/frontend/js/apps/TransformationApp/RawDataBody.jsx
+++ b/app/frontend/js/apps/TransformationApp/RawDataBody.jsx
@@ -1,13 +1,13 @@
 import React from "react";
 import { useSelector } from "react-redux";
-import { selectAppDetails } from "/js/features/AppDetailsSlice";
 import { selectUiAppDetails } from "/js/features/UiAppDetailsSlice";
 import ExpandCollapseIcon from "./components/ExpandCollapseIcon";
 import RecordViewer from "~/js/apps/TransformationApp/components/RecordViewer";
 import JumpTo from "./JumpTo";
+import { selectRawRecord } from "/js/features/RawRecordSlice";
 
 const RawDataBody = ({ clickToggleSection }) => {
-  const { rawRecord, format } = useSelector(selectAppDetails);
+  const { body, format } = useSelector(selectRawRecord);
   const { rawRecordExpanded } = useSelector(selectUiAppDetails);
 
   return (
@@ -27,7 +27,7 @@ const RawDataBody = ({ clickToggleSection }) => {
         </div>
       </div>
 
-      <RecordViewer record={rawRecord} format={format} />
+      <RecordViewer record={body} format={format} />
     </>
   );
 };

--- a/app/frontend/js/apps/TransformationApp/RawDataBody.jsx
+++ b/app/frontend/js/apps/TransformationApp/RawDataBody.jsx
@@ -20,7 +20,7 @@ const RawDataBody = ({ clickToggleSection }) => {
           <button
             onClick={() => clickToggleSection("rawRecordExpanded")}
             type="button"
-            className="btn btn-primary"
+            className="btn btn-outline-primary"
           >
             <ExpandCollapseIcon expanded={rawRecordExpanded} />
           </button>

--- a/app/frontend/js/apps/TransformationApp/RawDataBody.jsx
+++ b/app/frontend/js/apps/TransformationApp/RawDataBody.jsx
@@ -1,0 +1,35 @@
+import React from "react";
+import { useSelector } from "react-redux";
+import { selectAppDetails } from "/js/features/AppDetailsSlice";
+import { selectUiAppDetails } from "/js/features/UiAppDetailsSlice";
+import ExpandCollapseIcon from "./components/ExpandCollapseIcon";
+import RecordViewer from "~/js/apps/TransformationApp/components/RecordViewer";
+import JumpTo from "./JumpTo";
+
+const RawDataBody = ({ clickToggleSection }) => {
+  const { rawRecord, format } = useSelector(selectAppDetails);
+  const { rawRecordExpanded } = useSelector(selectUiAppDetails);
+
+  return (
+    <>
+      <div className="d-flex flex-row flex-nowrap justify-content-between mb-4">
+        <h5 className="text-truncate">Raw data</h5>
+
+        <div class="hstack gap-2">
+          <JumpTo />
+          <button
+            onClick={() => clickToggleSection("rawRecordExpanded")}
+            type="button"
+            className="btn btn-primary"
+          >
+            <ExpandCollapseIcon expanded={rawRecordExpanded} />
+          </button>
+        </div>
+      </div>
+
+      <RecordViewer record={rawRecord} format={format} />
+    </>
+  );
+};
+
+export default RawDataBody;

--- a/app/frontend/js/apps/TransformationApp/RawDataBody.jsx
+++ b/app/frontend/js/apps/TransformationApp/RawDataBody.jsx
@@ -15,7 +15,7 @@ const RawDataBody = ({ clickToggleSection }) => {
       <div className="d-flex flex-row flex-nowrap justify-content-between mb-4">
         <h5 className="text-truncate">Raw data</h5>
 
-        <div class="hstack gap-2">
+        <div className="hstack gap-2">
           <JumpTo />
           <button
             onClick={() => clickToggleSection("rawRecordExpanded")}

--- a/app/frontend/js/apps/TransformationApp/TransformationApp.jsx
+++ b/app/frontend/js/apps/TransformationApp/TransformationApp.jsx
@@ -78,7 +78,7 @@ const TransformationApp = ({}) => {
                       clickToggleSection("transformedRecordExpanded")
                     }
                     type="button"
-                    className="btn btn-primary"
+                    className="btn btn-outline-primary"
                   >
                     <ExpandCollapseIcon
                       expanded={uiAppDetails["transformedRecordExpanded"]}

--- a/app/frontend/js/apps/TransformationApp/TransformationApp.jsx
+++ b/app/frontend/js/apps/TransformationApp/TransformationApp.jsx
@@ -18,6 +18,7 @@ import Field from "~/js/apps/TransformationApp/components/Field";
 import FieldNavigationPanel from "./components/FieldNavigationPanel";
 import ExpandCollapseIcon from "./components/ExpandCollapseIcon";
 import HeaderActions from "./components/HeaderActions";
+import RawDataBody from "./RawDataBody";
 
 const TransformationApp = ({}) => {
   const dispatch = useDispatch();
@@ -61,20 +62,7 @@ const TransformationApp = ({}) => {
           <div className={rawRecordClasses}>
             <div className="card">
               <div className="card-body">
-                <div className="d-flex flex-row flex-nowrap justify-content-between mb-4">
-                  <h5 className="text-truncate">Raw data</h5>
-                  <button
-                    onClick={() => clickToggleSection("rawRecordExpanded")}
-                    type="button"
-                    className="btn btn-primary"
-                  >
-                    <ExpandCollapseIcon
-                      expanded={uiAppDetails["rawRecordExpanded"]}
-                    />
-                  </button>
-                </div>
-
-                <RecordViewer record={appDetails.rawRecord} format={appDetails.format} />
+                <RawDataBody clickToggleSection={clickToggleSection} />
               </div>
             </div>
           </div>
@@ -98,7 +86,10 @@ const TransformationApp = ({}) => {
                   </button>
                 </div>
 
-                <RecordViewer record={appDetails.transformedRecord} format="JSON" />
+                <RecordViewer
+                  record={appDetails.transformedRecord}
+                  format="JSON"
+                />
               </div>
             </div>
           </div>

--- a/app/frontend/js/features/RawRecordSlice.js
+++ b/app/frontend/js/features/RawRecordSlice.js
@@ -1,9 +1,40 @@
-import { createSlice } from "@reduxjs/toolkit";
+import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
+import { request } from "../utils/request";
+
+export const askNewRawRecord = createAsyncThunk(
+  "fields/askNewRawRecordStatus",
+  async (payload) => {
+    const { transformationDefinitionId, page, record } = payload;
+
+    const response = request
+      .get(
+        `/transformation_definitions/${transformationDefinitionId}/raw_records`,
+        { params: { page: page, record: record } }
+      )
+      .then(function (response) {
+        return response.data;
+      });
+
+    return response;
+  }
+);
 
 const rawRecordSlice = createSlice({
   name: "rawRecordSlice",
   initialState: {},
   reducers: {},
+  extraReducers: (builder) => {
+    builder
+      .addCase(askNewRawRecord.pending, (state) => {
+        state.isFetching = true;
+      })
+      .addCase(askNewRawRecord.fulfilled, (state, action) => {
+        state.isFetching = false;
+        state.page = action.payload.page;
+        state.record = action.payload.record;
+        state.body = action.payload.body;
+      });
+  },
 });
 
 const { actions, reducer } = rawRecordSlice;

--- a/app/frontend/js/features/RawRecordSlice.js
+++ b/app/frontend/js/features/RawRecordSlice.js
@@ -1,0 +1,15 @@
+import { createSlice } from "@reduxjs/toolkit";
+
+const rawRecordSlice = createSlice({
+  name: "rawRecordSlice",
+  initialState: {},
+  reducers: {},
+});
+
+const { actions, reducer } = rawRecordSlice;
+
+export const selectRawRecord = (state) => state.entities.rawRecord;
+
+export const {} = actions;
+
+export default reducer;

--- a/app/frontend/js/features/RawRecordSlice.js
+++ b/app/frontend/js/features/RawRecordSlice.js
@@ -33,6 +33,12 @@ const rawRecordSlice = createSlice({
         state.page = action.payload.page;
         state.record = action.payload.record;
         state.body = action.payload.body;
+
+        window.history.replaceState(
+          null,
+          null,
+          `${window.location.pathname}?page=${state.page}&record=${state.record}`
+        );
       });
   },
 });

--- a/app/frontend/js/store.js
+++ b/app/frontend/js/store.js
@@ -6,6 +6,7 @@ import {
 
 // entities
 import fields from "/js/features/FieldsSlice";
+import rawRecord from "/js/features/RawRecordSlice";
 import appDetails from "/js/features/AppDetailsSlice";
 
 // ui
@@ -22,6 +23,7 @@ export default function configureAppStore(preloadedState) {
     reducer: combineReducers({
       entities: combineReducers({
         fields,
+        rawRecord,
         appDetails,
       }),
       ui: combineReducers({

--- a/app/frontend/stylesheets/blocks/_jump-to.scss
+++ b/app/frontend/stylesheets/blocks/_jump-to.scss
@@ -1,9 +1,5 @@
 .jump-to {
   @include element('body') {
-    min-width: 17rem;
-  }
-
-  @include element('input') {
-    appearance: textfield;
+    min-width: 21rem;
   }
 }

--- a/app/frontend/stylesheets/blocks/_jump-to.scss
+++ b/app/frontend/stylesheets/blocks/_jump-to.scss
@@ -1,0 +1,9 @@
+.jump-to {
+  @include element('body') {
+    min-width: 17rem;
+  }
+
+  @include element('input') {
+    appearance: textfield;
+  }
+}

--- a/app/models/transformation_job.rb
+++ b/app/models/transformation_job.rb
@@ -19,19 +19,19 @@ class TransformationJob < ApplicationRecord
   def records(page = 1)
     return [] if transformation_definition.record_selector.blank? || extraction_job.documents[page].nil?
 
-    if transformation_definition.extraction_job.format == 'HTML'
+    case transformation_definition.extraction_job.format
+    when 'HTML'
       Nokogiri::HTML(extraction_job.documents[page].body)
-        .xpath(transformation_definition.record_selector)
-        .map(&:to_xml)
-    elsif transformation_definition.extraction_job.format == 'XML'
+              .xpath(transformation_definition.record_selector)
+              .map(&:to_xml)
+    when 'XML'
       Nokogiri::XML(extraction_job.documents[page].body)
-        .xpath(transformation_definition.record_selector)
-        .map(&:to_xml)
-    elsif transformation_definition.extraction_job.format == 'JSON'
+              .xpath(transformation_definition.record_selector)
+              .map(&:to_xml)
+    when 'JSON'
       JsonPath.new(transformation_definition.record_selector)
               .on(extraction_job.documents[page].body)
               .flatten
     end
-
   end
 end

--- a/app/slices/raw_record_slice.rb
+++ b/app/slices/raw_record_slice.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class RawRecordSlice
+  def initialize(transformation_definition, page, record)
+    @page = (page || 1).to_i
+    @record = (record || 1).to_i
+
+    @job = transformation_definition.extraction_job
+    @records = transformation_definition.records(@page)
+  end
+
+  def call
+    {
+      page: @page,
+      record: @record,
+      totalPages: @job.documents.total_pages,
+      totalRecords: @records.length,
+      format: @job.format,
+      body: @records[@record - 1]
+    }
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -33,6 +33,7 @@ module Harvester
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
     config.eager_load_paths << Rails.root.join('supplejack')
+    config.eager_load_paths << Rails.root.join('slices')
 
     config.time_zone = ENV.fetch('TIME_ZONE', 'Auckland')
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,6 +48,10 @@ Rails.application.routes.draw do
     end
   end
 
+  resources :transformation_definitions, only: [] do
+    resources :raw_records, only: %i[index]
+  end
+
   get :jobs, to: 'extraction_jobs#index', as: :extraction_jobs
 
   resources :destinations do


### PR DESCRIPTION
[MOVE THROUGH PREVIEW RECORDS: As Ting, I want to be able to navigate through my extracted records, so that I can see how my transformations work on other records](https://www.pivotaltracker.com/story/show/185477527)

STORY
=====

**Acceptance Criteria**
- Transformation is able to be moved forward and backward through extracted records/pages
- Ability to jump directly to a record/page


**Risks**
- ?

**Notes**
- [Figma Link](https://www.figma.com/file/UL5rFpFs9woyHNBdspYu3C/SJ-%7C-Proof-of-Concept?type=design&mode=design)
- Another way harvesters change the focus is adjusting the record_selector eg //items[./license="cc-by"]  to test how transformation works on specific rights scenarios. This, and swapping to a different extract is achievable by editing the transformation definition.

**Impacts**
- Very important, currently can only test 1 record from the whole extraction, which might be a dull record.
