### PR TITLE
SHARED DEFINITIONS (II) CLONING: As Dan I want to be able to use and edit an existing definition safely, so that I don't accidentally change existing pipelines.

### DIFF
--- a/app/controllers/extraction_definitions_controller.rb
+++ b/app/controllers/extraction_definitions_controller.rb
@@ -68,18 +68,13 @@ class ExtractionDefinitionsController < ApplicationController
   end
 
   def clone
-    cloned_extraction_definition = @extraction_definition.clone(
-      @pipeline,
-      @harvest_definition,
-      extraction_definition_params['name']
-    )
+    cloned_extraction_definition = @extraction_definition.clone(@pipeline, @harvest_definition,
+                                                                extraction_definition_params['name'])
 
     if cloned_extraction_definition
-      redirect_to edit_pipeline_harvest_definition_extraction_definition_path(
-        @pipeline,
-        @harvest_definition,
-        cloned_extraction_definition
-      ), notice: t('.success')
+      flash.notice = t('.success')
+      redirect_to edit_pipeline_harvest_definition_extraction_definition_path(@pipeline, @harvest_definition,
+                                                                              cloned_extraction_definition)
     else
       flash.alert = t('.failure')
       redirect_to pipeline_path(@pipeline)
@@ -126,10 +121,8 @@ class ExtractionDefinitionsController < ApplicationController
 
   def extraction_definition_params
     safe_params = params.require(:extraction_definition).permit(
-      :pipeline_id,
-      :name, :format, :base_url, :throttle, :page, :per_page,
-      :total_selector, :kind, :destination_id, :source_id, :enrichment_url,
-      :paginated
+      :pipeline_id, :name, :format, :base_url, :throttle, :page, :per_page,
+      :total_selector, :kind, :destination_id, :source_id, :enrichment_url, :paginated
     )
     merge_last_edited_by(safe_params)
   end

--- a/app/controllers/extraction_definitions_controller.rb
+++ b/app/controllers/extraction_definitions_controller.rb
@@ -68,10 +68,11 @@ class ExtractionDefinitionsController < ApplicationController
   end
 
   def clone
-    cloned_extraction_definition = @extraction_definition.clone(@pipeline, @harvest_definition,
+    cloned_extraction_definition = @extraction_definition.clone(@pipeline,
                                                                 extraction_definition_params['name'])
 
-    if cloned_extraction_definition
+    if cloned_extraction_definition.save
+      @harvest_definition.update(extraction_definition: cloned_extraction_definition)
       flash.notice = t('.success')
       redirect_to edit_pipeline_harvest_definition_extraction_definition_path(@pipeline, @harvest_definition,
                                                                               cloned_extraction_definition)

--- a/app/controllers/extraction_definitions_controller.rb
+++ b/app/controllers/extraction_definitions_controller.rb
@@ -73,8 +73,7 @@ class ExtractionDefinitionsController < ApplicationController
     if clone.save
       @harvest_definition.update(extraction_definition: clone)
       flash.notice = t('.success')
-      redirect_to edit_pipeline_harvest_definition_extraction_definition_path(@pipeline, @harvest_definition,
-                                                                              clone)
+      successful_clone_path(clone)
     else
       flash.alert = t('.failure')
       redirect_to pipeline_path(@pipeline)
@@ -100,6 +99,15 @@ class ExtractionDefinitionsController < ApplicationController
       )
     else
       pipeline_path(@pipeline)
+    end
+  end
+
+  def successful_clone_path(clone)
+    if @harvest_definition.enrichment?
+      redirect_to edit_pipeline_harvest_definition_extraction_definition_path(@pipeline, @harvest_definition,
+                                                                              clone)
+    else
+      redirect_to pipeline_harvest_definition_extraction_definition_path(@pipeline, @harvest_definition, clone)
     end
   end
 

--- a/app/controllers/extraction_definitions_controller.rb
+++ b/app/controllers/extraction_definitions_controller.rb
@@ -68,22 +68,17 @@ class ExtractionDefinitionsController < ApplicationController
   end
 
   def clone
-    cloned_extraction_definition = @extraction_definition.dup
+    cloned_extraction_definition = @extraction_definition.clone(
+      @pipeline,
+      @harvest_definition,
+      extraction_definition_params['name']
+    )
 
-    @extraction_definition.requests.each do |request|
-      cloned_request = request.dup
-      request.parameters.each do |parameter|
-        cloned_request.parameters << parameter.dup
-      end
-
-      cloned_extraction_definition.requests << cloned_request
-      cloned_extraction_definition.save
-    end
-
-    cloned_extraction_definition.update(pipeline: @pipeline, name: extraction_definition_params['name'])
-    @harvest_definition.update(extraction_definition: cloned_extraction_definition)
-
-    redirect_to edit_pipeline_harvest_definition_extraction_definition_path(@pipeline, @harvest_definition, cloned_extraction_definition)
+    redirect_to edit_pipeline_harvest_definition_extraction_definition_path(
+      @pipeline,
+      @harvest_definition,
+      cloned_extraction_definition
+    )
   end
 
   private

--- a/app/controllers/extraction_definitions_controller.rb
+++ b/app/controllers/extraction_definitions_controller.rb
@@ -72,8 +72,7 @@ class ExtractionDefinitionsController < ApplicationController
 
     if clone.save
       @harvest_definition.update(extraction_definition: clone)
-      flash.notice = t('.success')
-      successful_clone_path(clone)
+      redirect_to successful_clone_path(clone), notice: t('.success')
     else
       flash.alert = t('.failure')
       redirect_to pipeline_path(@pipeline)
@@ -83,31 +82,26 @@ class ExtractionDefinitionsController < ApplicationController
   private
 
   def create_redirect_path
-    if @extraction_definition.harvest?
-      pipeline_harvest_definition_extraction_definition_path(
-        @pipeline, @harvest_definition, @extraction_definition
-      )
-    else
-      pipeline_path(@pipeline)
-    end
+    return pipeline_path(@pipeline) unless @extraction_definition.harvest?
+
+    pipeline_harvest_definition_extraction_definition_path(
+      @pipeline, @harvest_definition, @extraction_definition
+    )
   end
 
   def update_redirect_path
-    if @extraction_definition.harvest?
-      pipeline_harvest_definition_extraction_definition_path(
-        @pipeline, @harvest_definition, @extraction_definition
-      )
-    else
-      pipeline_path(@pipeline)
-    end
+    return pipeline_path(@pipeline) unless @extraction_definition.harvest?
+
+    pipeline_harvest_definition_extraction_definition_path(
+      @pipeline, @harvest_definition, @extraction_definition
+    )
   end
 
   def successful_clone_path(clone)
     if @harvest_definition.enrichment?
-      redirect_to edit_pipeline_harvest_definition_extraction_definition_path(@pipeline, @harvest_definition,
-                                                                              clone)
+      edit_pipeline_harvest_definition_extraction_definition_path(@pipeline, @harvest_definition, clone)
     else
-      redirect_to pipeline_harvest_definition_extraction_definition_path(@pipeline, @harvest_definition, clone)
+      pipeline_harvest_definition_extraction_definition_path(@pipeline, @harvest_definition, clone)
     end
   end
 

--- a/app/controllers/extraction_definitions_controller.rb
+++ b/app/controllers/extraction_definitions_controller.rb
@@ -74,11 +74,16 @@ class ExtractionDefinitionsController < ApplicationController
       extraction_definition_params['name']
     )
 
-    redirect_to edit_pipeline_harvest_definition_extraction_definition_path(
-      @pipeline,
-      @harvest_definition,
-      cloned_extraction_definition
-    )
+    if cloned_extraction_definition
+      redirect_to edit_pipeline_harvest_definition_extraction_definition_path(
+        @pipeline,
+        @harvest_definition,
+        cloned_extraction_definition
+      ), notice: t('.success')
+    else
+      flash.alert = t('.failure')
+      redirect_to pipeline_path(@pipeline)
+    end
   end
 
   private

--- a/app/controllers/extraction_definitions_controller.rb
+++ b/app/controllers/extraction_definitions_controller.rb
@@ -68,14 +68,13 @@ class ExtractionDefinitionsController < ApplicationController
   end
 
   def clone
-    cloned_extraction_definition = @extraction_definition.clone(@pipeline,
-                                                                extraction_definition_params['name'])
+    clone = @extraction_definition.clone(@pipeline, extraction_definition_params['name'])
 
-    if cloned_extraction_definition.save
-      @harvest_definition.update(extraction_definition: cloned_extraction_definition)
+    if clone.save
+      @harvest_definition.update(extraction_definition: clone)
       flash.notice = t('.success')
       redirect_to edit_pipeline_harvest_definition_extraction_definition_path(@pipeline, @harvest_definition,
-                                                                              cloned_extraction_definition)
+                                                                              clone)
     else
       flash.alert = t('.failure')
       redirect_to pipeline_path(@pipeline)

--- a/app/controllers/fields_controller.rb
+++ b/app/controllers/fields_controller.rb
@@ -57,7 +57,7 @@ class FieldsController < ApplicationController
   end
 
   def find_fields
-    @fields = @transformation_definition.fields.where(id: params['fields'])
+    @fields = @transformation_definition.fields.where(id: params['fields']).order(created_at: :desc)
   end
 
   def find_field

--- a/app/controllers/transformation_definitions_controller.rb
+++ b/app/controllers/transformation_definitions_controller.rb
@@ -71,8 +71,8 @@ class TransformationDefinitionsController < ApplicationController
     if clone.save
       @harvest_definition.update(transformation_definition: clone)
       flash.notice = t('.success')
-      redirect_to edit_pipeline_harvest_definition_transformation_definition_path(@pipeline, @harvest_definition,
-                                                                                  clone)
+      redirect_to pipeline_harvest_definition_transformation_definition_path(@pipeline, @harvest_definition,
+                                                                             clone)
     else
       flash.alert = t('.failure')
       redirect_to pipeline_path(@pipeline)

--- a/app/controllers/transformation_definitions_controller.rb
+++ b/app/controllers/transformation_definitions_controller.rb
@@ -66,14 +66,13 @@ class TransformationDefinitionsController < ApplicationController
   end
 
   def clone
-    cloned_transformation_definition = @transformation_definition.clone(@pipeline,
-                                                                        transformation_definition_params['name'])
+    clone = @transformation_definition.clone(@pipeline, transformation_definition_params['name'])
 
-    if cloned_transformation_definition.save
-      @harvest_definition.update(transformation_definition: cloned_transformation_definition)
+    if clone.save
+      @harvest_definition.update(transformation_definition: clone)
       flash.notice = t('.success')
       redirect_to edit_pipeline_harvest_definition_transformation_definition_path(@pipeline, @harvest_definition,
-                                                                                  cloned_transformation_definition)
+                                                                                  clone)
     else
       flash.alert = t('.failure')
       redirect_to pipeline_path(@pipeline)

--- a/app/controllers/transformation_definitions_controller.rb
+++ b/app/controllers/transformation_definitions_controller.rb
@@ -66,10 +66,11 @@ class TransformationDefinitionsController < ApplicationController
   end
 
   def clone
-    cloned_transformation_definition = @transformation_definition.clone(@pipeline, @harvest_definition,
+    cloned_transformation_definition = @transformation_definition.clone(@pipeline,
                                                                         transformation_definition_params['name'])
 
-    if cloned_transformation_definition
+    if cloned_transformation_definition.save
+      @harvest_definition.update(transformation_definition: cloned_transformation_definition)
       flash.notice = t('.success')
       redirect_to edit_pipeline_harvest_definition_transformation_definition_path(@pipeline, @harvest_definition,
                                                                                   cloned_transformation_definition)

--- a/app/controllers/transformation_definitions_controller.rb
+++ b/app/controllers/transformation_definitions_controller.rb
@@ -70,8 +70,9 @@ class TransformationDefinitionsController < ApplicationController
                                                                         transformation_definition_params['name'])
 
     if cloned_transformation_definition
+      flash.notice = t('.success')
       redirect_to edit_pipeline_harvest_definition_transformation_definition_path(@pipeline, @harvest_definition,
-                                                                                  cloned_transformation_definition), notice: t('.success')
+                                                                                  cloned_transformation_definition)
     else
       flash.alert = t('.failure')
       redirect_to pipeline_path(@pipeline)

--- a/app/controllers/transformation_definitions_controller.rb
+++ b/app/controllers/transformation_definitions_controller.rb
@@ -5,7 +5,7 @@ class TransformationDefinitionsController < ApplicationController
 
   before_action :find_pipeline
   before_action :find_harvest_definition
-  before_action :find_transformation_definition, only: %w[show edit update destroy]
+  before_action :find_transformation_definition, only: %w[show edit update destroy clone]
   before_action :find_extraction_jobs, only: %w[new create edit update]
 
   def show
@@ -63,6 +63,19 @@ class TransformationDefinitionsController < ApplicationController
       result: (@transformation_definition.records.first || []),
       format: @transformation_definition.extraction_job.extraction_definition.format
     }
+  end
+
+  def clone
+    cloned_transformation_definition = @transformation_definition.clone(@pipeline, @harvest_definition,
+                                                                        transformation_definition_params['name'])
+
+    if cloned_transformation_definition
+      redirect_to edit_pipeline_harvest_definition_transformation_definition_path(@pipeline, @harvest_definition,
+                                                                                  cloned_transformation_definition), notice: t('.success')
+    else
+      flash.alert = t('.failure')
+      redirect_to pipeline_path(@pipeline)
+    end
   end
 
   private

--- a/app/frontend/js/apps/ExtractionApp/ExtractionApp.jsx
+++ b/app/frontend/js/apps/ExtractionApp/ExtractionApp.jsx
@@ -1,5 +1,4 @@
-import React, { useState, useEffect } from "react";
-import { map, filter } from "lodash";
+import React from "react";
 import { useSelector } from "react-redux";
 
 import HeaderActions from "/js/apps/ExtractionApp/components/HeaderActions";

--- a/app/frontend/js/apps/ExtractionApp/components/NavTabs.jsx
+++ b/app/frontend/js/apps/ExtractionApp/components/NavTabs.jsx
@@ -104,9 +104,9 @@ const NavTabs = () => {
   return createPortal(
     <>
       <ul className="nav nav-tabs mt-4" role="tablist">
-        {pageOne()}
-        {appDetails.extractionDefinition.paginated && pageTwo()}
-        {shared()}
+        { (appDetails.extractionDefinition.paginated || sharedDefinitions.length > 1) && pageOne()}
+        { appDetails.extractionDefinition.paginated && pageTwo()}
+        { sharedDefinitions.length > 1 && shared()}
       </ul>
     </>,
     document.getElementById("react-nav-tabs")

--- a/app/frontend/js/apps/ExtractionApp/components/NavTabs.jsx
+++ b/app/frontend/js/apps/ExtractionApp/components/NavTabs.jsx
@@ -79,7 +79,7 @@ const NavTabs = () => {
             dispatch(activateSharedDefinitionsTab());
           }}
         >
-          Shared Definitions ({sharedDefinitions.length})
+          Shared ({sharedDefinitions.length} pipelines)
         </button>
       </li>
     );
@@ -104,9 +104,11 @@ const NavTabs = () => {
   return createPortal(
     <>
       <ul className="nav nav-tabs mt-4" role="tablist">
-        { (appDetails.extractionDefinition.paginated || sharedDefinitions.length > 1) && pageOne()}
-        { appDetails.extractionDefinition.paginated && pageTwo()}
-        { sharedDefinitions.length > 1 && shared()}
+        {(appDetails.extractionDefinition.paginated ||
+          sharedDefinitions.length > 1) &&
+          pageOne()}
+        {appDetails.extractionDefinition.paginated && pageTwo()}
+        {sharedDefinitions.length > 1 && shared()}
       </ul>
     </>,
     document.getElementById("react-nav-tabs")

--- a/app/frontend/js/apps/TransformationApp/components/NavTabs.jsx
+++ b/app/frontend/js/apps/TransformationApp/components/NavTabs.jsx
@@ -23,7 +23,7 @@ const NavTabs = () => {
 
   return createPortal(
     <>
-      { sharedDefinitions.length > 1 && (
+      {sharedDefinitions.length > 1 && (
         <ul className="nav nav-tabs mt-4" role="tablist">
           <li className="nav-item" role="presentation">
             <button
@@ -43,7 +43,7 @@ const NavTabs = () => {
               role="tab"
               onClick={() => dispatch(toggleSharedDefinitionsTab(true))}
             >
-              Shared Definitions ({sharedDefinitions.length})
+              Shared ({sharedDefinitions.length} pipelines)
             </button>
           </li>
         </ul>

--- a/app/frontend/js/apps/TransformationApp/components/NavTabs.jsx
+++ b/app/frontend/js/apps/TransformationApp/components/NavTabs.jsx
@@ -23,29 +23,31 @@ const NavTabs = () => {
 
   return createPortal(
     <>
-      <ul className="nav nav-tabs mt-4" role="tablist">
-        <li className="nav-item" role="presentation">
-          <button
-            className={transformationClasses}
-            type="button"
-            role="tab"
-            onClick={() => dispatch(toggleSharedDefinitionsTab(false))}
-          >
-            Transformation
-          </button>
-        </li>
+      { sharedDefinitions.length > 1 && (
+        <ul className="nav nav-tabs mt-4" role="tablist">
+          <li className="nav-item" role="presentation">
+            <button
+              className={transformationClasses}
+              type="button"
+              role="tab"
+              onClick={() => dispatch(toggleSharedDefinitionsTab(false))}
+            >
+              Transformation
+            </button>
+          </li>
 
-        <li className="nav-item" role="presentation">
-          <button
-            className={sharedDefinitionClasses}
-            type="button"
-            role="tab"
-            onClick={() => dispatch(toggleSharedDefinitionsTab(true))}
-          >
-            Shared Definitions ({sharedDefinitions.length})
-          </button>
-        </li>
-      </ul>
+          <li className="nav-item" role="presentation">
+            <button
+              className={sharedDefinitionClasses}
+              type="button"
+              role="tab"
+              onClick={() => dispatch(toggleSharedDefinitionsTab(true))}
+            >
+              Shared Definitions ({sharedDefinitions.length})
+            </button>
+          </li>
+        </ul>
+      )}
     </>,
     document.getElementById("react-nav-tabs")
   );

--- a/app/helpers/pipelines_helper.rb
+++ b/app/helpers/pipelines_helper.rb
@@ -9,6 +9,12 @@ module PipelinesHelper
     "Your #{type} is ready to run"
   end
 
+  def definition_edit_text(definition, type)
+    return "Edit shared #{type.capitalize}" if definition.shared?
+
+    "Edit #{type}"
+  end
+
   private
 
   def extraction_definition_help_text(definition, type)

--- a/app/models/extraction_definition.rb
+++ b/app/models/extraction_definition.rb
@@ -69,17 +69,16 @@ class ExtractionDefinition < ApplicationRecord
   end
 
   def clone(pipeline, harvest_definition, name)
-    cloned_extraction_definition = dup
+    cloned_extraction_definition = ExtractionDefinition.new(dup.attributes.merge(name:, pipeline:))
 
     requests.each do |request|
       cloned_request = request.dup
       request.parameters.each { |parameter| cloned_request.parameters << parameter.dup }
 
       cloned_extraction_definition.requests << cloned_request
-      cloned_extraction_definition.save
     end
 
-    cloned_extraction_definition.update!(pipeline:, name:)
+    cloned_extraction_definition.save
     harvest_definition.update(extraction_definition: cloned_extraction_definition)
 
     cloned_extraction_definition

--- a/app/models/extraction_definition.rb
+++ b/app/models/extraction_definition.rb
@@ -68,7 +68,7 @@ class ExtractionDefinition < ApplicationRecord
     harvest_definitions.count > 1
   end
 
-  def clone(pipeline, harvest_definition, name)
+  def clone(pipeline, name)
     cloned_extraction_definition = ExtractionDefinition.new(dup.attributes.merge(name:, pipeline:))
 
     requests.each do |request|
@@ -77,9 +77,6 @@ class ExtractionDefinition < ApplicationRecord
 
       cloned_extraction_definition.requests << cloned_request
     end
-
-    cloned_extraction_definition.save
-    harvest_definition.update(extraction_definition: cloned_extraction_definition)
 
     cloned_extraction_definition
   end

--- a/app/models/extraction_definition.rb
+++ b/app/models/extraction_definition.rb
@@ -13,12 +13,15 @@ class ExtractionDefinition < ApplicationRecord
   has_many :extraction_jobs, dependent: :restrict_with_exception
   has_many :requests, dependent: :destroy
   has_many :parameters, through: :requests
+  validates :name, uniqueness: true
 
   enum :kind, { harvest: 0, enrichment: 1 }
 
   after_create do
-    self.name = "#{pipeline.name.parameterize}__#{kind}-extraction-#{id}"
-    save!
+    if name.blank?
+      self.name = "#{pipeline.name.parameterize}__#{kind}-extraction-#{id}"
+      save!
+    end
   end
 
   # find good regex or another implementation

--- a/app/models/extraction_definition.rb
+++ b/app/models/extraction_definition.rb
@@ -70,15 +70,13 @@ class ExtractionDefinition < ApplicationRecord
 
     requests.each do |request|
       cloned_request = request.dup
-      request.parameters.each do |parameter|
-        cloned_request.parameters << parameter.dup
-      end
+      request.parameters.each { |parameter| cloned_request.parameters << parameter.dup }
 
       cloned_extraction_definition.requests << cloned_request
       cloned_extraction_definition.save
     end
 
-    cloned_extraction_definition.update(pipeline:, name:)
+    cloned_extraction_definition.update!(pipeline:, name:)
     harvest_definition.update(extraction_definition: cloned_extraction_definition)
 
     cloned_extraction_definition

--- a/app/models/extraction_definition.rb
+++ b/app/models/extraction_definition.rb
@@ -64,4 +64,23 @@ class ExtractionDefinition < ApplicationRecord
   def shared?
     harvest_definitions.count > 1
   end
+
+  def clone(pipeline, harvest_definition, name)
+    cloned_extraction_definition = dup
+
+    requests.each do |request|
+      cloned_request = request.dup
+      request.parameters.each do |parameter|
+        cloned_request.parameters << parameter.dup
+      end
+
+      cloned_extraction_definition.requests << cloned_request
+      cloned_extraction_definition.save
+    end
+
+    cloned_extraction_definition.update(pipeline:, name:)
+    harvest_definition.update(extraction_definition: cloned_extraction_definition)
+
+    cloned_extraction_definition
+  end
 end

--- a/app/models/harvest_definition.rb
+++ b/app/models/harvest_definition.rb
@@ -40,4 +40,8 @@ class HarvestDefinition < ApplicationRecord
       }
     }
   end
+
+  def clone(pipeline)
+    HarvestDefinition.new(dup.attributes.merge(pipeline:))
+  end
 end

--- a/app/models/pipeline.rb
+++ b/app/models/pipeline.rb
@@ -7,7 +7,7 @@ class Pipeline < ApplicationRecord
 
   has_many :pipeline_jobs, dependent: :destroy
 
-  validates :name, presence: true
+  validates :name, presence: true, uniqueness: true
 
   def harvest
     harvest_definitions.find_by(kind: 'harvest')

--- a/app/models/transformation_definition.rb
+++ b/app/models/transformation_definition.rb
@@ -34,4 +34,20 @@ class TransformationDefinition < ApplicationRecord
   def shared?
     harvest_definitions.count > 1
   end
+
+  def clone(pipeline, harvest_definition, name)
+    cloned_transformation_definition = dup
+
+    fields.each do |field|
+      cloned_field = field.dup
+
+      cloned_transformation_definition.fields << cloned_field
+    end
+
+    cloned_transformation_definition.save
+    cloned_transformation_definition.update(pipeline:, name:)
+    harvest_definition.update(transformation_definition: cloned_transformation_definition)
+
+    cloned_transformation_definition
+  end
 end

--- a/app/models/transformation_definition.rb
+++ b/app/models/transformation_definition.rb
@@ -9,11 +9,15 @@ class TransformationDefinition < ApplicationRecord
   has_many :fields, dependent: :destroy
   enum :kind, { harvest: 0, enrichment: 1 }
 
+  validates :name, uniqueness: true
+
   validates :record_selector, presence: true
 
   after_create do
-    self.name = "#{pipeline.name.parameterize}__#{kind}-transformation-#{id}"
-    save!
+    if name.blank?
+      self.name = "#{pipeline.name.parameterize}__#{kind}-transformation-#{id}"
+      save!
+    end
   end
 
   # Returns the records from the job based on the given record_selector

--- a/app/models/transformation_definition.rb
+++ b/app/models/transformation_definition.rb
@@ -39,7 +39,7 @@ class TransformationDefinition < ApplicationRecord
     harvest_definitions.count > 1
   end
 
-  def clone(pipeline, harvest_definition, name)
+  def clone(pipeline, name)
     cloned_transformation_definition = TransformationDefinition.new(dup.attributes.merge(name:, pipeline:))
 
     fields.each do |field|
@@ -47,9 +47,6 @@ class TransformationDefinition < ApplicationRecord
 
       cloned_transformation_definition.fields << cloned_field
     end
-
-    cloned_transformation_definition.save
-    harvest_definition.update(transformation_definition: cloned_transformation_definition)
 
     cloned_transformation_definition
   end

--- a/app/models/transformation_definition.rb
+++ b/app/models/transformation_definition.rb
@@ -40,7 +40,7 @@ class TransformationDefinition < ApplicationRecord
   end
 
   def clone(pipeline, harvest_definition, name)
-    cloned_transformation_definition = dup
+    cloned_transformation_definition = TransformationDefinition.new(dup.attributes.merge(name:, pipeline:))
 
     fields.each do |field|
       cloned_field = field.dup
@@ -49,7 +49,6 @@ class TransformationDefinition < ApplicationRecord
     end
 
     cloned_transformation_definition.save
-    cloned_transformation_definition.update(pipeline:, name:)
     harvest_definition.update(transformation_definition: cloned_transformation_definition)
 
     cloned_transformation_definition

--- a/app/views/extraction_jobs/index.html.erb
+++ b/app/views/extraction_jobs/index.html.erb
@@ -33,4 +33,7 @@
   </ul>
 <% end %>
 
-<%= render partial: 'jobs/jobs', locals: { jobs: @extraction_jobs, type: 'extraction', pipeline: @pipeline, harvest_definition: @harvest_definition, extraction_definition: @extraction_definition } %>
+<%= render partial: 'jobs/jobs',
+           locals: { jobs: @extraction_jobs, type: 'extraction', pipeline: @pipeline,
+                     harvest_definition: @harvest_definition,
+                     extraction_definition: @extraction_definition } %>

--- a/app/views/extraction_jobs/index.html.erb
+++ b/app/views/extraction_jobs/index.html.erb
@@ -33,4 +33,4 @@
   </ul>
 <% end %>
 
-<%= render partial: 'jobs/jobs', locals: { jobs: @extraction_jobs, type: 'extraction', pipeline: @pipeline } %>
+<%= render partial: 'jobs/jobs', locals: { jobs: @extraction_jobs, type: 'extraction', pipeline: @pipeline, harvest_definition: @harvest_definition, extraction_definition: @extraction_definition } %>

--- a/app/views/jobs/_jobs.html.erb
+++ b/app/views/jobs/_jobs.html.erb
@@ -2,17 +2,7 @@
   <div class='row'>
     <%- jobs.each do |job| %>
       <div class='col-3'>
-        <% definition = job.send("#{type}_definition") %>
-        <% next if definition.nil? %>
-
-        <% if type == 'harvest' %>
-          <% path = send("pipeline_harvest_definition_#{type}_job_path", pipeline, pipeline.harvest, job) %>
-        <% else %>
-          <% path = send("pipeline_harvest_definition_#{type}_definition_#{type}_job_path", pipeline, pipeline.harvest,
-                         pipeline.harvest.extraction_definition, job) %>
-        <% end %>
-
-        <%= link_to path, class: 'card mb-3' do %>
+        <%= link_to pipeline_harvest_definition_extraction_definition_extraction_job_path(pipeline, harvest_definition, extraction_definition, job), class: 'card mb-3' do %>
           <div class='card-body'>
             <h5 class='card-title'><%= job.name %></h5>
             <h6 class='card-subtitle'><%= job.updated_at.to_fs(:light) %></h6>

--- a/app/views/jobs/_jobs.html.erb
+++ b/app/views/jobs/_jobs.html.erb
@@ -2,7 +2,10 @@
   <div class='row'>
     <%- jobs.each do |job| %>
       <div class='col-3'>
-        <%= link_to pipeline_harvest_definition_extraction_definition_extraction_job_path(pipeline, harvest_definition, extraction_definition, job), class: 'card mb-3' do %>
+        <%= link_to pipeline_harvest_definition_extraction_definition_extraction_job_path(
+              pipeline, harvest_definition, extraction_definition, job
+            ),
+                    class: 'card mb-3' do %>
           <div class='card-body'>
             <h5 class='card-title'><%= job.name %></h5>
             <h6 class='card-subtitle'><%= job.updated_at.to_fs(:light) %></h6>

--- a/app/views/pipelines/_card.html.erb
+++ b/app/views/pipelines/_card.html.erb
@@ -117,12 +117,13 @@
       <div class="modal-body">
         <p>Please name the new definition which you are cloning</p>
 
-        <% clone_url = send("clone_pipeline_harvest_definition_#{type}_definition_path", @pipeline, block_definition, definition) %>
+        <% clone_url = send("clone_pipeline_harvest_definition_#{type}_definition_path", @pipeline, block_definition,
+                            definition) %>
 
         <%= vertical_form_with(model: definition,
                                url: clone_url, method: :post) do |f| %>
 
-          <%= f.text_field :name, required: true, class: 'form-control', value: "[COPY] #{definition.name}" %>
+          <%= f.text_field :name, required: true, class: 'form-control', value: "[CLONE] #{definition.name}" %>
 
           <br>
 

--- a/app/views/pipelines/_card.html.erb
+++ b/app/views/pipelines/_card.html.erb
@@ -117,7 +117,7 @@
       <div class="modal-body">
         <p>Please name the new definition which you are cloning</p>
 
-        <%= vertical_form_with(model: definition, url: clone_pipeline_harvest_definition_extraction_definition_path(@pipeline, @harvest_definition, definition), method: :post) do |f| %>
+        <%= vertical_form_with(model: definition, url: clone_pipeline_harvest_definition_extraction_definition_path(@pipeline, block_definition, definition), method: :post) do |f| %>
 
           <%= f.text_field :name, required: true, class: 'form-control', value: "[COPY] #{definition.name}" %>
 

--- a/app/views/pipelines/_card.html.erb
+++ b/app/views/pipelines/_card.html.erb
@@ -30,7 +30,7 @@
               class="dropdown-item card__control-action"
               href="#"
               data-bs-toggle='modal'
-              data-bs-target="<%= "#clone-definition-#{definition.id}" %>">
+              data-bs-target="<%= "#clone-definition-#{type}-#{definition.id}" %>">
                 <i class="bi bi-layers me-2"></i>Clone definition
               </a>
           </li> 
@@ -80,7 +80,7 @@
 
 <div
   class="modal fade"
-  id="<%= "remove-reference-#{definition.id}" %>">
+  id="<%= "remove-reference-#{type}-#{definition.id}" %>">
   <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-header">
@@ -107,7 +107,7 @@
 
 <div
   class="modal fade"
-  id="<%= "clone-definition-#{definition.id}" %>">
+  id="<%= "clone-definition-#{type}-#{definition.id}" %>">
   <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-header">
@@ -117,7 +117,7 @@
       <div class="modal-body">
         <p>Please name the new definition which you are cloning</p>
 
-        <%= vertical_form_with(model: definition, url: clone_pipeline_harvest_definition_extraction_definition_path(@pipeline, block_definition, definition), method: :post) do |f| %>
+        <%= vertical_form_with(model: definition, url: send("clone_pipeline_harvest_definition_#{type}_definition_path", @pipeline, block_definition, definition), method: :post) do |f| %>
 
           <%= f.text_field :name, required: true, class: 'form-control', value: "[COPY] #{definition.name}" %>
 

--- a/app/views/pipelines/_card.html.erb
+++ b/app/views/pipelines/_card.html.erb
@@ -33,7 +33,7 @@
               data-bs-target="<%= "#clone-definition-#{type}-#{definition.id}" %>">
                 <i class="bi bi-layers me-2"></i>Clone definition
               </a>
-          </li> 
+          </li>
         <% end %>
 
         <li>
@@ -117,11 +117,14 @@
       <div class="modal-body">
         <p>Please name the new definition which you are cloning</p>
 
-        <%= vertical_form_with(model: definition, url: send("clone_pipeline_harvest_definition_#{type}_definition_path", @pipeline, block_definition, definition), method: :post) do |f| %>
+        <% clone_url = send("clone_pipeline_harvest_definition_#{type}_definition_path", @pipeline, block_definition, definition) %>
+
+        <%= vertical_form_with(model: definition,
+                               url: clone_url, method: :post) do |f| %>
 
           <%= f.text_field :name, required: true, class: 'form-control', value: "[COPY] #{definition.name}" %>
 
-          <br />
+          <br>
 
           <button type="button" class="btn btn-danger" data-bs-dismiss="modal">Cancel</button>
           <button type="submit" class="btn btn-primary">Clone and edit new</button>

--- a/app/views/pipelines/_card.html.erb
+++ b/app/views/pipelines/_card.html.erb
@@ -12,7 +12,7 @@
     </h6>
 
     <% if definition.shared? %>
-      <span class="badge text-bg-light">Shared</span>
+      <span class="badge text-bg-light">Shared (<%= "#{definition.harvest_definitions.count} pipelines" %>)</span>
     <% end %>
 
     <div class="btn-group card__control">
@@ -31,7 +31,7 @@
               href="#"
               data-bs-toggle='modal'
               data-bs-target="<%= "#clone-definition-#{type}-#{definition.id}" %>">
-                <i class="bi bi-layers me-2"></i>Clone definition
+                <i class="bi bi-layers me-2"></i>Clone and edit new definition
               </a>
           </li>
         <% end %>

--- a/app/views/pipelines/_card.html.erb
+++ b/app/views/pipelines/_card.html.erb
@@ -24,6 +24,18 @@
           <% end %>
         </li>
 
+        <% if definition.shared? %>
+          <li>
+            <a
+              class="dropdown-item card__control-action"
+              href="#"
+              data-bs-toggle='modal'
+              data-bs-target="<%= "#clone-definition-#{definition.id}" %>">
+                <i class="bi bi-layers me-2"></i>Clone definition
+              </a>
+          </li> 
+        <% end %>
+
         <li>
           <a
             class="dropdown-item card__control-action"
@@ -88,6 +100,33 @@
                       },
                       method: :patch,
                       class: 'btn btn-danger' %>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div
+  class="modal fade"
+  id="<%= "clone-definition-#{definition.id}" %>">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Clone and edit new definition</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <p>Please name the new definition which you are cloning</p>
+
+        <%= vertical_form_with(model: definition, url: clone_pipeline_harvest_definition_extraction_definition_path(@pipeline, @harvest_definition, definition), method: :post) do |f| %>
+
+          <%= f.text_field :name, required: true, class: 'form-control', value: "[COPY] #{definition.name}" %>
+
+          <br />
+
+          <button type="button" class="btn btn-danger" data-bs-dismiss="modal">Cancel</button>
+          <button type="submit" class="btn btn-primary">Clone and edit new</button>
+
+        <% end %>
       </div>
     </div>
   </div>

--- a/app/views/pipelines/show.html.erb
+++ b/app/views/pipelines/show.html.erb
@@ -229,6 +229,14 @@
       <div class='col-6'>
         <% if @harvest_definition.extraction_definition.present? %>
 
+          <% 
+            if @harvest_definition.extraction_definition.shared?
+              edit_text = 'Edit shared Extraction'
+            else
+              edit_text = 'Edit Extraction'
+            end
+          %>
+
           <%= render partial: 'pipelines/card',
                      locals: {
                        pipeline: @pipeline,
@@ -240,7 +248,7 @@
                 @harvest_definition,
                 @harvest_definition.extraction_definition
               ),
-                       edit_text: 'Edit Extraction',
+                       edit_text:,
                        jobs_path:
               pipeline_harvest_definition_extraction_definition_extraction_jobs_path(
                 @pipeline,
@@ -280,6 +288,14 @@
       <div class='col-6'>
         <% if @harvest_definition.transformation_definition.present? %>
 
+          <% 
+            if @harvest_definition.transformation_definition.shared?
+              edit_text = 'Edit shared Transformation'
+            else
+              edit_text = 'Edit Transformation'
+            end
+          %>
+
           <%= render partial: 'pipelines/card',
                      locals: {
                        pipeline: @pipeline,
@@ -291,7 +307,7 @@
                 @harvest_definition,
                 @harvest_definition.transformation_definition
               ),
-                       edit_text: 'Edit Transformation',
+                       edit_text:,
                        jobs_path: ''
                      } %>
 
@@ -383,6 +399,14 @@
         <div class='col-6'>
           <% if enrichment_definition.extraction_definition.present? %>
 
+          <% 
+            if enrichment_definition.extraction_definition.shared?
+              edit_text = 'Edit shared Extraction'
+            else
+              edit_text = 'Edit Extraction'
+            end
+          %>
+
           <%= render partial: 'pipelines/card',
                      locals: {
                        pipeline: @pipeline,
@@ -394,7 +418,7 @@
                   enrichment_definition,
                   enrichment_definition.extraction_definition
                 ),
-                       edit_text: 'Edit Extraction',
+                       edit_text:,
                        jobs_path:
                 pipeline_harvest_definition_extraction_definition_extraction_jobs_path(
                   @pipeline,
@@ -470,6 +494,14 @@
         <div class='col-6'>
           <% if enrichment_definition.transformation_definition.present? %>
 
+          <% 
+            if enrichment_definition.transformation_definition.shared?
+              edit_text = 'Edit shared Transformation'
+            else
+              edit_text = 'Edit Transformation'
+            end
+          %>
+
           <%= render partial: 'pipelines/card',
                      locals: {
                        pipeline: @pipeline,
@@ -481,7 +513,7 @@
                   @harvest_definition,
                   enrichment_definition.transformation_definition
                 ),
-                       edit_text: 'Edit Transformation',
+                       edit_text:,
                        jobs_path: ''
                      } %>
 

--- a/app/views/pipelines/show.html.erb
+++ b/app/views/pipelines/show.html.erb
@@ -229,13 +229,6 @@
       <div class='col-6'>
         <% if @harvest_definition.extraction_definition.present? %>
 
-edit_text = if @harvest_definition.extraction_definition.shared?
-              'Edit shared Extraction'
-            else
-              'Edit Extraction'
-                        end
-          %>
-
           <%= render partial: 'pipelines/card',
                      locals: {
                        pipeline: @pipeline,
@@ -247,7 +240,7 @@ edit_text = if @harvest_definition.extraction_definition.shared?
                 @harvest_definition,
                 @harvest_definition.extraction_definition
               ),
-                       edit_text:,
+                       edit_text: definition_edit_text(@harvest_definition.extraction_definition, 'extraction'),
                        jobs_path:
               pipeline_harvest_definition_extraction_definition_extraction_jobs_path(
                 @pipeline,
@@ -287,13 +280,6 @@ edit_text = if @harvest_definition.extraction_definition.shared?
       <div class='col-6'>
         <% if @harvest_definition.transformation_definition.present? %>
 
-edit_text = if @harvest_definition.transformation_definition.shared?
-              'Edit shared Transformation'
-            else
-              'Edit Transformation'
-                        end
-          %>
-
           <%= render partial: 'pipelines/card',
                      locals: {
                        pipeline: @pipeline,
@@ -305,7 +291,7 @@ edit_text = if @harvest_definition.transformation_definition.shared?
                 @harvest_definition,
                 @harvest_definition.transformation_definition
               ),
-                       edit_text:,
+                       edit_text: definition_edit_text(@harvest_definition.transformation_definition, 'transformation'),
                        jobs_path: ''
                      } %>
 
@@ -397,13 +383,6 @@ edit_text = if @harvest_definition.transformation_definition.shared?
         <div class='col-6'>
           <% if enrichment_definition.extraction_definition.present? %>
 
-edit_text = if enrichment_definition.extraction_definition.shared?
-              'Edit shared Extraction'
-            else
-              'Edit Extraction'
-                        end
-          %>
-
           <%= render partial: 'pipelines/card',
                      locals: {
                        pipeline: @pipeline,
@@ -415,7 +394,7 @@ edit_text = if enrichment_definition.extraction_definition.shared?
                   enrichment_definition,
                   enrichment_definition.extraction_definition
                 ),
-                       edit_text:,
+                       edit_text: definition_edit_text(enrichment_definition.extraction_definition, 'extraction'),
                        jobs_path:
                 pipeline_harvest_definition_extraction_definition_extraction_jobs_path(
                   @pipeline,
@@ -491,13 +470,6 @@ edit_text = if enrichment_definition.extraction_definition.shared?
         <div class='col-6'>
           <% if enrichment_definition.transformation_definition.present? %>
 
-edit_text = if enrichment_definition.transformation_definition.shared?
-              'Edit shared Transformation'
-            else
-              'Edit Transformation'
-                        end
-          %>
-
           <%= render partial: 'pipelines/card',
                      locals: {
                        pipeline: @pipeline,
@@ -509,7 +481,8 @@ edit_text = if enrichment_definition.transformation_definition.shared?
                   @harvest_definition,
                   enrichment_definition.transformation_definition
                 ),
-                       edit_text:,
+                       edit_text: definition_edit_text(enrichment_definition.transformation_definition,
+                                                       'transformation'),
                        jobs_path: ''
                      } %>
 

--- a/app/views/pipelines/show.html.erb
+++ b/app/views/pipelines/show.html.erb
@@ -229,12 +229,11 @@
       <div class='col-6'>
         <% if @harvest_definition.extraction_definition.present? %>
 
-          <% 
-            if @harvest_definition.extraction_definition.shared?
-              edit_text = 'Edit shared Extraction'
+edit_text = if @harvest_definition.extraction_definition.shared?
+              'Edit shared Extraction'
             else
-              edit_text = 'Edit Extraction'
-            end
+              'Edit Extraction'
+                        end
           %>
 
           <%= render partial: 'pipelines/card',
@@ -288,12 +287,11 @@
       <div class='col-6'>
         <% if @harvest_definition.transformation_definition.present? %>
 
-          <% 
-            if @harvest_definition.transformation_definition.shared?
-              edit_text = 'Edit shared Transformation'
+edit_text = if @harvest_definition.transformation_definition.shared?
+              'Edit shared Transformation'
             else
-              edit_text = 'Edit Transformation'
-            end
+              'Edit Transformation'
+                        end
           %>
 
           <%= render partial: 'pipelines/card',
@@ -399,12 +397,11 @@
         <div class='col-6'>
           <% if enrichment_definition.extraction_definition.present? %>
 
-          <% 
-            if enrichment_definition.extraction_definition.shared?
-              edit_text = 'Edit shared Extraction'
+edit_text = if enrichment_definition.extraction_definition.shared?
+              'Edit shared Extraction'
             else
-              edit_text = 'Edit Extraction'
-            end
+              'Edit Extraction'
+                        end
           %>
 
           <%= render partial: 'pipelines/card',
@@ -494,12 +491,11 @@
         <div class='col-6'>
           <% if enrichment_definition.transformation_definition.present? %>
 
-          <% 
-            if enrichment_definition.transformation_definition.shared?
-              edit_text = 'Edit shared Transformation'
+edit_text = if enrichment_definition.transformation_definition.shared?
+              'Edit shared Transformation'
             else
-              edit_text = 'Edit Transformation'
-            end
+              'Edit Transformation'
+                        end
           %>
 
           <%= render partial: 'pipelines/card',

--- a/app/views/pipelines/show.html.erb
+++ b/app/views/pipelines/show.html.erb
@@ -91,6 +91,42 @@
       <% end %>
     <% end %>
 
+    <button
+      type="button"
+      class="btn btn-outline-primary"
+      data-bs-toggle="modal"
+      data-bs-target="#clone-pipeline">
+      <i class="bi bi-layers" aria-hidden="true"></i> Clone pipeline
+    </button>
+
+    <div
+      class="modal fade"
+      id="clone-pipeline">
+      <div class="modal-dialog">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title">Clone and edit new pipeline</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+          </div>
+          <div class="modal-body">
+            <p>Please name the new pipeline which you are cloning</p>
+
+            <%= vertical_form_with(model: @pipeline,
+                                  url: clone_pipeline_path(@pipeline), method: :post) do |f| %>
+
+              <%= f.text_field :name, required: true, class: 'form-control', value: "[COPY] #{@pipeline.name}" %>
+
+              <br>
+
+              <button type="button" class="btn btn-danger" data-bs-dismiss="modal">Cancel</button>
+              <button type="submit" class="btn btn-primary">Clone and edit new</button>
+
+            <% end %>
+          </div>
+        </div>
+      </div>
+    </div>
+
     <%= link_to edit_pipeline_path(@pipeline), class: 'me-1 btn btn-outline-primary' do %>
       <i class="bi bi-pencil-square" aria-hidden="true"></i> Edit
     <% end %>

--- a/app/views/pipelines/show.html.erb
+++ b/app/views/pipelines/show.html.erb
@@ -112,9 +112,9 @@
             <p>Please name the new pipeline which you are cloning</p>
 
             <%= vertical_form_with(model: @pipeline,
-                                  url: clone_pipeline_path(@pipeline), method: :post) do |f| %>
+                                   url: clone_pipeline_path(@pipeline), method: :post) do |f| %>
 
-              <%= f.text_field :name, required: true, class: 'form-control', value: "[COPY] #{@pipeline.name}" %>
+              <%= f.text_field :name, required: true, class: 'form-control', value: "[CLONE] #{@pipeline.name}" %>
 
               <br>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -51,6 +51,9 @@ en:
     destroy:
       success: Extraction Definition deleted successfully
       failure: There was an issue deleting your Extraction Definition
+    clone:
+      success: Extraction Definition cloned successfully
+      failure: Extraction Definition clone failed
 
   extraction_jobs:
     create:
@@ -112,6 +115,9 @@ en:
     destroy:
       success: Transformation Definition deleted successfully
       failure: There was an issue deleting your Transformation Definition
+    clone:
+      success: Transformation Definition cloned successfully
+      failure: Transformation Definition clone failed
 
   two_factor_setups:
     create:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -92,6 +92,9 @@ en:
     destroy:
       success: Pipeline deleted successfully
       failure: There was an issue deleting your Pipeline
+    clone:
+      success: Pipeline cloned successfully
+      failure: Pipeline clone failed. Please confirm that your Pipeline name is unique and then try again.
   
   pipeline_jobs:
     create:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -53,7 +53,7 @@ en:
       failure: There was an issue deleting your Extraction Definition
     clone:
       success: Extraction Definition cloned successfully
-      failure: Extraction Definition clone failed
+      failure: Extraction Definition clone failed. Please confirm that your Extraction Definition name is unique and then try again.
 
   extraction_jobs:
     create:
@@ -117,7 +117,7 @@ en:
       failure: There was an issue deleting your Transformation Definition
     clone:
       success: Transformation Definition cloned successfully
-      failure: Transformation Definition clone failed
+      failure: Transformation Definition clone failed. Please confirm that your Transformation Definition name is unique and then try again.
 
   two_factor_setups:
     create:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,10 @@ Rails.application.routes.draw do
   end
   
   resources :pipelines, only: %i[index show create update edit destroy] do
+    member do
+      post :clone
+    end
+    
     resources :pipeline_jobs, only: %i[create show index] do
       post :cancel, on: :member
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,9 +19,7 @@ Rails.application.routes.draw do
   end
   
   resources :pipelines, only: %i[index show create update edit destroy] do
-    member do
-      post :clone
-    end
+    post :clone, on: :member
     
     resources :pipeline_jobs, only: %i[create show index] do
       post :cancel, on: :member

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,6 +44,7 @@ Rails.application.routes.draw do
 
       resources :transformation_definitions, only: %i[new create show edit update destroy] do
         post :test, on: :collection
+        post :clone, on: :member
 
         resources :fields, only: %i[create update destroy] do
           post :run, on: :collection

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,6 +31,10 @@ Rails.application.routes.draw do
           post :test_enrichment_extraction
         end
 
+        member do
+          post :clone
+        end
+
         resources :extraction_jobs, only: %i[index show create destroy]
 
         resources :requests do
@@ -40,7 +44,6 @@ Rails.application.routes.draw do
 
       resources :transformation_definitions, only: %i[new create show edit update destroy] do
         post :test, on: :collection
-        post :update_harvest_definitions, on: :member
 
         resources :fields, only: %i[create update destroy] do
           post :run, on: :collection

--- a/db/migrate/20230924223008_add_uniqueness_constraint_to_definition_name.rb
+++ b/db/migrate/20230924223008_add_uniqueness_constraint_to_definition_name.rb
@@ -1,0 +1,7 @@
+class AddUniquenessConstraintToDefinitionName < ActiveRecord::Migration[7.0]
+  def change
+    add_index :extraction_definitions, :name, unique: true
+    add_index :transformation_definitions, :name, unique: true
+    add_index :pipelines, :name, unique: true
+  end
+end

--- a/db/migrate/20230924223008_add_uniqueness_constraint_to_definition_name.rb
+++ b/db/migrate/20230924223008_add_uniqueness_constraint_to_definition_name.rb
@@ -1,7 +1,7 @@
 class AddUniquenessConstraintToDefinitionName < ActiveRecord::Migration[7.0]
   def change
-    add_index :extraction_definitions, :name, unique: true
-    add_index :transformation_definitions, :name, unique: true
-    add_index :pipelines, :name, unique: true
+    add_index :extraction_definitions, :name, unique: true, length: 255
+    add_index :transformation_definitions, :name, unique: true, length: 255
+    add_index :pipelines, :name, unique: true, length: 255
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_10_230548) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_24_223008) do
   create_table "destinations", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "url", null: false
@@ -21,7 +21,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_10_230548) do
   end
 
   create_table "extraction_definitions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.text "name"
+    t.string "name"
     t.string "format"
     t.string "base_url"
     t.integer "throttle", default: 0, null: false
@@ -40,6 +40,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_10_230548) do
     t.bigint "pipeline_id"
     t.index ["destination_id"], name: "index_extraction_definitions_on_destination_id"
     t.index ["last_edited_by_id"], name: "index_extraction_definitions_on_last_edited_by_id"
+    t.index ["name"], name: "index_extraction_definitions_on_name", unique: true
     t.index ["pipeline_id"], name: "index_extraction_definitions_on_pipeline_id"
   end
 
@@ -68,7 +69,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_10_230548) do
   end
 
   create_table "harvest_definitions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.text "name"
+    t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "extraction_definition_id"
@@ -180,6 +181,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_10_230548) do
     t.datetime "updated_at", null: false
     t.bigint "last_edited_by_id"
     t.index ["last_edited_by_id"], name: "index_pipelines_on_last_edited_by_id"
+    t.index ["name"], name: "index_pipelines_on_name", unique: true
   end
 
   create_table "requests", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
@@ -191,7 +193,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_10_230548) do
   end
 
   create_table "transformation_definitions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.text "name"
+    t.string "name"
     t.string "record_selector", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -201,6 +203,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_10_230548) do
     t.bigint "last_edited_by_id"
     t.index ["extraction_job_id"], name: "index_transformation_definitions_on_extraction_job_id"
     t.index ["last_edited_by_id"], name: "index_transformation_definitions_on_last_edited_by_id"
+    t.index ["name"], name: "index_transformation_definitions_on_name", unique: true
     t.index ["pipeline_id"], name: "index_transformation_definitions_on_pipeline_id"
   end
 

--- a/spec/factories/pipeline.rb
+++ b/spec/factories/pipeline.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :pipeline do
-    name { 'DigitalNZ Production' }
+    name        { Faker::Name.unique.name }
     description { 'Description' }
 
     trait :figshare do

--- a/spec/factories/transformation_definition.rb
+++ b/spec/factories/transformation_definition.rb
@@ -2,7 +2,6 @@
 
 FactoryBot.define do
   factory :transformation_definition do
-    name { Faker::Company.name }
     record_selector { '$..results' }
 
     extraction_job

--- a/spec/models/extraction_definition_spec.rb
+++ b/spec/models/extraction_definition_spec.rb
@@ -141,7 +141,7 @@ RSpec.describe ExtractionDefinition, type: :model do
     let!(:harvest_definition)    { create(:harvest_definition, extraction_definition:, pipeline:) }
     let!(:harvest_definition_two)    { create(:harvest_definition, extraction_definition:, pipeline:) }
 
-    it 'creates a new Extraction Definition with the same details for the provided HarvestDefinition' do
+    it 'creates a new Extraction Definition with the same details' do
       cloned_extraction_definition = extraction_definition.clone(pipeline_two, 'clone')
 
       cloned_extraction_definition.save

--- a/spec/models/extraction_definition_spec.rb
+++ b/spec/models/extraction_definition_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe ExtractionDefinition, type: :model do
     let!(:harvest_definition)    { create(:harvest_definition, extraction_definition:, pipeline:) }
     let!(:harvest_definition_two)    { create(:harvest_definition, extraction_definition:, pipeline:) }
 
-    it 'creates a new Extraction Definition as the one provided for the specified Harvest Definition' do
+    it 'creates a new Extraction Definition with the same details for the provided HarvestDefinition' do
       cloned_extraction_definition = extraction_definition.clone(pipeline_two, harvest_definition_two, 'clone')
 
       expect(cloned_extraction_definition.requests.count).to eq extraction_definition.requests.count
@@ -158,7 +158,7 @@ RSpec.describe ExtractionDefinition, type: :model do
       end
     end
 
-    it 'assigns the new ExtractionDefinition to the provided Pipeline and Extraction Definition' do
+    it 'assigns the new ExtractionDefinition to the provided Pipeline and Harvest Definition' do
       expect(harvest_definition_two.extraction_definition).to eq extraction_definition
 
       cloned_extraction_definition = extraction_definition.clone(pipeline_two, harvest_definition_two, 'clone')

--- a/spec/models/extraction_definition_spec.rb
+++ b/spec/models/extraction_definition_spec.rb
@@ -142,8 +142,9 @@ RSpec.describe ExtractionDefinition, type: :model do
     let!(:harvest_definition_two)    { create(:harvest_definition, extraction_definition:, pipeline:) }
 
     it 'creates a new Extraction Definition with the same details for the provided HarvestDefinition' do
-      cloned_extraction_definition = extraction_definition.clone(pipeline_two, harvest_definition_two, 'clone')
+      cloned_extraction_definition = extraction_definition.clone(pipeline_two, 'clone')
 
+      cloned_extraction_definition.save
       expect(cloned_extraction_definition.requests.count).to eq extraction_definition.requests.count
 
       cloned_extraction_definition.requests.zip(extraction_definition.requests) do |cloned_request, original_request|
@@ -160,28 +161,18 @@ RSpec.describe ExtractionDefinition, type: :model do
       end
     end
 
-    it 'assigns the new ExtractionDefinition to the provided Pipeline and Harvest Definition' do
+    it 'assigns the new ExtractionDefinition to the provided Pipeline' do
       expect(harvest_definition_two.extraction_definition).to eq extraction_definition
 
-      cloned_extraction_definition = extraction_definition.clone(pipeline_two, harvest_definition_two, 'clone')
-
-      harvest_definition_two.reload
+      cloned_extraction_definition = extraction_definition.clone(pipeline_two, 'clone')
+      cloned_extraction_definition.save
       expect(cloned_extraction_definition.pipeline).to eq pipeline_two
-      expect(harvest_definition_two.extraction_definition).to eq cloned_extraction_definition
-    end
-
-    it 'turns a shared ExtractionDefinition into a stand alone one if it was only shared with one other pipeline' do
-      expect(extraction_definition.shared?).to eq true
-
-      extraction_definition.clone(pipeline_two, harvest_definition_two, 'clone')
-      extraction_definition.reload
-
-      expect(extraction_definition.shared?).to eq false
     end
 
     it 'assigns the provided name to the ExtractionDefinition clone' do
-      cloned_extraction_definition = extraction_definition.clone(pipeline_two, harvest_definition_two, 'clone')
+      cloned_extraction_definition = extraction_definition.clone(pipeline_two, 'clone')
 
+      cloned_extraction_definition.save
       expect(cloned_extraction_definition.name).to eq 'clone'
     end
   end

--- a/spec/models/extraction_definition_spec.rb
+++ b/spec/models/extraction_definition_spec.rb
@@ -64,6 +64,8 @@ RSpec.describe ExtractionDefinition, type: :model do
 
       expect(extraction_definition.errors[:pipeline]).to include 'must exist'
     end
+
+    it { is_expected.to validate_uniqueness_of(:name).case_insensitive.with_message('has already been taken') }
   end
 
   describe '#validations base_url' do

--- a/spec/models/pipeline_spec.rb
+++ b/spec/models/pipeline_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe Pipeline, type: :model do
     subject { build(:pipeline) }
 
     it { is_expected.to validate_presence_of(:name) }
+    it { is_expected.to validate_uniqueness_of(:name).case_insensitive.with_message('has already been taken') }
   end
 
   describe 'associations' do

--- a/spec/models/transformation_definition_spec.rb
+++ b/spec/models/transformation_definition_spec.rb
@@ -61,6 +61,8 @@ RSpec.describe TransformationDefinition, type: :model do
     it 'automatically generates a sensible name' do
       expect(subject.name).to eq "national-library-of-new-zealand__harvest-transformation-#{subject.id}"
     end
+    
+    it { is_expected.to validate_uniqueness_of(:name).case_insensitive.with_message('has already been taken') }
   end
 
   describe '#shared?' do

--- a/spec/models/transformation_definition_spec.rb
+++ b/spec/models/transformation_definition_spec.rb
@@ -79,4 +79,48 @@ RSpec.describe TransformationDefinition, type: :model do
       expect(standalone.shared?).to eq false
     end
   end
+
+  describe '#clone' do
+    let(:pipeline_two)               { create(:pipeline) }
+
+    let!(:harvest_definition)        { create(:harvest_definition, transformation_definition: subject, pipeline:) }
+    let!(:harvest_definition_two)    { create(:harvest_definition, transformation_definition: subject, pipeline: pipeline_two) }
+
+    it 'creates a new TransformationDefinition with the same details for the provided HarvestDefinition' do
+      cloned_transformation_definition = subject.clone(pipeline_two, harvest_definition_two, 'clone')
+
+      expect(cloned_transformation_definition.fields.count).to eq subject.fields.count
+
+      cloned_transformation_definition.fields.zip(subject.fields) do |cloned_field, field|
+        expect(cloned_field.name).to eq field.name
+        expect(cloned_field.block).to eq field.block
+        expect(cloned_field.kind).to eq field.kind
+      end
+    end
+
+    it 'assigns the new Transformation Definition to the provided Pipeline and Harvest Definition' do
+      expect(harvest_definition_two.transformation_definition).to eq subject
+
+      cloned_transformation_definition = subject.clone(pipeline_two, harvest_definition_two, 'clone')
+
+      harvest_definition_two.reload
+      expect(cloned_transformation_definition.pipeline).to eq pipeline_two
+      expect(harvest_definition_two.transformation_definition).to eq cloned_transformation_definition
+    end
+
+    it 'turns a shared Transformation Definition into a standalone one if it was only shared with one other pipeline' do
+      expect(subject.shared?).to eq true
+
+      subject.clone(pipeline_two, harvest_definition_two, 'clone')
+      subject.reload
+
+      expect(subject.shared?).to eq false
+    end
+
+    it 'assigns the provided name to the ExtractionDefinition clone' do
+      cloned_transformation_definition = subject.clone(pipeline_two, harvest_definition_two, 'clone')
+
+      expect(cloned_transformation_definition.name).to eq 'clone'
+    end
+  end
 end

--- a/spec/models/transformation_definition_spec.rb
+++ b/spec/models/transformation_definition_spec.rb
@@ -89,8 +89,9 @@ RSpec.describe TransformationDefinition, type: :model do
     let!(:harvest_definition_two)    { create(:harvest_definition, transformation_definition: subject, pipeline: pipeline_two) }
 
     it 'creates a new TransformationDefinition with the same details for the provided HarvestDefinition' do
-      cloned_transformation_definition = subject.clone(pipeline_two, harvest_definition_two, 'clone')
+      cloned_transformation_definition = subject.clone(pipeline_two, 'clone')
 
+      cloned_transformation_definition.save
       expect(cloned_transformation_definition.fields.count).to eq subject.fields.count
 
       cloned_transformation_definition.fields.zip(subject.fields) do |cloned_field, field|
@@ -100,28 +101,19 @@ RSpec.describe TransformationDefinition, type: :model do
       end
     end
 
-    it 'assigns the new Transformation Definition to the provided Pipeline and Harvest Definition' do
+    it 'assigns the new Transformation Definition to the provided Pipeline' do
       expect(harvest_definition_two.transformation_definition).to eq subject
 
-      cloned_transformation_definition = subject.clone(pipeline_two, harvest_definition_two, 'clone')
+      cloned_transformation_definition = subject.clone(pipeline_two, 'clone')
 
-      harvest_definition_two.reload
+      cloned_transformation_definition.save
       expect(cloned_transformation_definition.pipeline).to eq pipeline_two
-      expect(harvest_definition_two.transformation_definition).to eq cloned_transformation_definition
-    end
-
-    it 'turns a shared Transformation Definition into a standalone one if it was only shared with one other pipeline' do
-      expect(subject.shared?).to eq true
-
-      subject.clone(pipeline_two, harvest_definition_two, 'clone')
-      subject.reload
-
-      expect(subject.shared?).to eq false
     end
 
     it 'assigns the provided name to the ExtractionDefinition clone' do
-      cloned_transformation_definition = subject.clone(pipeline_two, harvest_definition_two, 'clone')
+      cloned_transformation_definition = subject.clone(pipeline_two, 'clone')
 
+      cloned_transformation_definition.save
       expect(cloned_transformation_definition.name).to eq 'clone'
     end
   end

--- a/spec/models/transformation_definition_spec.rb
+++ b/spec/models/transformation_definition_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe TransformationDefinition, type: :model do
     let!(:harvest_definition)        { create(:harvest_definition, transformation_definition: subject, pipeline:) }
     let!(:harvest_definition_two)    { create(:harvest_definition, transformation_definition: subject, pipeline: pipeline_two) }
 
-    it 'creates a new TransformationDefinition with the same details for the provided HarvestDefinition' do
+    it 'creates a new TransformationDefinition with the same details' do
       cloned_transformation_definition = subject.clone(pipeline_two, 'clone')
 
       cloned_transformation_definition.save

--- a/spec/requests/extraction_definitions_spec.rb
+++ b/spec/requests/extraction_definitions_spec.rb
@@ -201,7 +201,7 @@ RSpec.describe 'ExtractionDefinitions', type: :request do
   end
 
   describe '#clone' do
-    let!(:extraction_definition)    { create(:extraction_definition) }
+    let!(:extraction_definition)    { create(:extraction_definition, name: 'one') }
     let!(:request_one)              { create(:request, :figshare_initial_request, extraction_definition:) }
     let!(:request_two)              { create(:request, :figshare_main_request, extraction_definition:) }
 
@@ -233,14 +233,10 @@ RSpec.describe 'ExtractionDefinitions', type: :request do
     end
 
     context 'when the clone fails' do
-      before do
-        allow_any_instance_of(ExtractionDefinition).to receive(:clone).and_return(false)
-      end
-
       it 'redirects to the pipeline page' do
         post clone_pipeline_harvest_definition_extraction_definition_path(pipeline_two, harvest_definition_two, extraction_definition), params: {
           extraction_definition: {
-            name: 'copy'
+            name: extraction_definition.name
           }
         }
   
@@ -250,13 +246,13 @@ RSpec.describe 'ExtractionDefinitions', type: :request do
       it 'displays an appropriate message' do
         post clone_pipeline_harvest_definition_extraction_definition_path(pipeline_two, harvest_definition_two, extraction_definition), params: {
           extraction_definition: {
-            name: 'copy'
+            name: extraction_definition.name
           }
         }
 
         follow_redirect!
         
-        expect(response.body).to include('Extraction Definition clone failed')
+        expect(response.body).to include('Extraction Definition clone failed. Please confirm that your Extraction Definition name is unique and then try again.')
       end
     end
   end

--- a/spec/requests/extraction_definitions_spec.rb
+++ b/spec/requests/extraction_definitions_spec.rb
@@ -208,14 +208,56 @@ RSpec.describe 'ExtractionDefinitions', type: :request do
     let(:pipeline_two)              { create(:pipeline) }
     let!(:harvest_definition_two)    { create(:harvest_definition, extraction_definition:, pipeline:) }
 
-    it 'redirects to the Extraction Definition Edit page' do
-      post clone_pipeline_harvest_definition_extraction_definition_path(pipeline_two, harvest_definition_two, extraction_definition), params: {
-        extraction_definition: {
-          name: 'copy'
+    context 'when the clone is successful' do
+      it 'redirects to the Extraction Definition Edit page' do
+        post clone_pipeline_harvest_definition_extraction_definition_path(pipeline_two, harvest_definition_two, extraction_definition), params: {
+          extraction_definition: {
+            name: 'copy'
+          }
         }
-      }
+  
+        expect(response).to redirect_to edit_pipeline_harvest_definition_extraction_definition_path(pipeline_two, harvest_definition_two, ExtractionDefinition.last)
+      end
 
-      expect(response).to redirect_to edit_pipeline_harvest_definition_extraction_definition_path(pipeline_two, harvest_definition_two, ExtractionDefinition.last)
+      it 'displays an appropriate message' do
+        post clone_pipeline_harvest_definition_extraction_definition_path(pipeline_two, harvest_definition_two, extraction_definition), params: {
+          extraction_definition: {
+            name: 'copy'
+          }
+        }
+
+        follow_redirect!
+        
+        expect(response.body).to include('Extraction Definition cloned successfully')
+      end
+    end
+
+    context 'when the clone fails' do
+      before do
+        allow_any_instance_of(ExtractionDefinition).to receive(:clone).and_return(false)
+      end
+
+      it 'redirects to the pipeline page' do
+        post clone_pipeline_harvest_definition_extraction_definition_path(pipeline_two, harvest_definition_two, extraction_definition), params: {
+          extraction_definition: {
+            name: 'copy'
+          }
+        }
+  
+        expect(response).to redirect_to pipeline_path(pipeline_two)
+      end
+
+      it 'displays an appropriate message' do
+        post clone_pipeline_harvest_definition_extraction_definition_path(pipeline_two, harvest_definition_two, extraction_definition), params: {
+          extraction_definition: {
+            name: 'copy'
+          }
+        }
+
+        follow_redirect!
+        
+        expect(response.body).to include('Extraction Definition clone failed')
+      end
     end
   end
 end

--- a/spec/requests/extraction_definitions_spec.rb
+++ b/spec/requests/extraction_definitions_spec.rb
@@ -209,14 +209,14 @@ RSpec.describe 'ExtractionDefinitions', type: :request do
     let!(:harvest_definition_two)    { create(:harvest_definition, extraction_definition:, pipeline:) }
 
     context 'when the clone is successful' do
-      it 'redirects to the Extraction Definition Edit page' do
+      it 'redirects to the Extraction Definition page' do
         post clone_pipeline_harvest_definition_extraction_definition_path(pipeline_two, harvest_definition_two, extraction_definition), params: {
           extraction_definition: {
             name: 'copy'
           }
         }
   
-        expect(response).to redirect_to edit_pipeline_harvest_definition_extraction_definition_path(pipeline_two, harvest_definition_two, ExtractionDefinition.last)
+        expect(response).to redirect_to pipeline_harvest_definition_extraction_definition_path(pipeline_two, harvest_definition_two, ExtractionDefinition.last)
       end
 
       it 'displays an appropriate message' do

--- a/spec/requests/extraction_definitions_spec.rb
+++ b/spec/requests/extraction_definitions_spec.rb
@@ -208,62 +208,6 @@ RSpec.describe 'ExtractionDefinitions', type: :request do
     let(:pipeline_two)              { create(:pipeline) }
     let!(:harvest_definition_two)    { create(:harvest_definition, extraction_definition:, pipeline:) }
 
-    it 'creates a new ExtractionDefinition with the same attributes as the one provided for the specified HarvestDefinition' do
-      expect do
-        post clone_pipeline_harvest_definition_extraction_definition_path(pipeline_two, harvest_definition_two, extraction_definition), params: { 
-          extraction_definition: {
-            name: 'copy'
-          }
-        }
-      end.to change(ExtractionDefinition, :count).by(1)
-
-      cloned_extraction_definition = ExtractionDefinition.last
-
-      expect(cloned_extraction_definition.requests.count).to eq extraction_definition.requests.count
-
-      cloned_extraction_definition.requests.zip(extraction_definition.requests) do |cloned_request, original_request|
-        expect(cloned_request.http_method).to eq original_request.http_method
-
-        expect(cloned_request.parameters.count).to eq original_request.parameters.count
-
-        cloned_request.parameters.zip(original_request.parameters) do |cloned_parameter, original_parameter| 
-          expect(cloned_parameter.name).to eq original_parameter.name
-          expect(cloned_parameter.content).to eq original_parameter.content
-          expect(cloned_parameter.kind).to eq original_parameter.kind
-          expect(cloned_parameter.content_type).to eq original_parameter.content_type
-        end
-      end
-    end
-
-    it 'assigns the new ExtractionDefinition to the provided Pipeline and Extraction Definition' do
-      expect(harvest_definition_two.extraction_definition).to eq extraction_definition
-
-      post clone_pipeline_harvest_definition_extraction_definition_path(pipeline_two, harvest_definition_two, extraction_definition), params: {
-        extraction_definition: {
-          name: 'copy'
-        }
-      }
-
-      cloned_extraction_definition = ExtractionDefinition.last
-
-      harvest_definition_two.reload
-
-      expect(cloned_extraction_definition.pipeline).to eq pipeline_two
-      expect(harvest_definition_two.extraction_definition).to eq cloned_extraction_definition
-    end
-
-    it 'turns a shared ExtractionDefinition into a stand alone one if it was only shared with one other pipeline' do
-      expect(extraction_definition.shared?).to eq true
-
-      post clone_pipeline_harvest_definition_extraction_definition_path(pipeline_two, harvest_definition_two, extraction_definition), params: {
-        extraction_definition: {
-          name: 'copy'
-        }
-      }
-
-      expect(extraction_definition.shared?).to eq false
-    end
-
     it 'redirects to the Extraction Definition Edit page' do
       post clone_pipeline_harvest_definition_extraction_definition_path(pipeline_two, harvest_definition_two, extraction_definition), params: {
         extraction_definition: {
@@ -272,18 +216,6 @@ RSpec.describe 'ExtractionDefinitions', type: :request do
       }
 
       expect(response).to redirect_to edit_pipeline_harvest_definition_extraction_definition_path(pipeline_two, harvest_definition_two, ExtractionDefinition.last)
-    end
-
-    it 'assigns the provided name to the Extraction Definition clone' do
-      post clone_pipeline_harvest_definition_extraction_definition_path(pipeline_two, harvest_definition_two, extraction_definition), params: { 
-        extraction_definition: {
-          name: 'cloned_extraction_definition'
-        }
-      }
-
-      cloned_extraction_definition = ExtractionDefinition.last
-
-      expect(cloned_extraction_definition.name).to eq 'cloned_extraction_definition'
     end
   end
 end

--- a/spec/requests/fields_spec.rb
+++ b/spec/requests/fields_spec.rb
@@ -163,6 +163,18 @@ RSpec.describe 'Fields', type: :request do
 
         expect(body['deletion_reasons']).to include 'delete_block'
       end
+
+      it 'returns a new record with the fields ordered by created at' do
+        post run_pipeline_harvest_definition_transformation_definition_fields_path(pipeline, harvest_definition, transformation_definition), params: {
+          fields: [field_one.id, field_two.id],
+          page: 1,
+          record: 1
+        }
+
+        transformed_record = JSON.parse(response.body)['transformation']['transformed_record']
+
+        expect(transformed_record.keys.first).to eq 'dc_identifier'
+      end
     end
   end
 end

--- a/spec/requests/transformation_definitions_spec.rb
+++ b/spec/requests/transformation_definitions_spec.rb
@@ -225,14 +225,10 @@ RSpec.describe 'Transformation Definitions', type: :request do
     end
 
     context 'when the clone fails' do
-      before do
-        allow_any_instance_of(TransformationDefinition).to receive(:clone).and_return false
-      end
-
       it 'redirects to the Pipeline page' do
         post clone_pipeline_harvest_definition_transformation_definition_path(pipeline, harvest_definition, transformation_definition), params: {
           transformation_definition: {
-            name: 'copy'
+            name: transformation_definition.name
           }
         }
 
@@ -242,13 +238,13 @@ RSpec.describe 'Transformation Definitions', type: :request do
       it 'displays an appropriate message' do
         post clone_pipeline_harvest_definition_transformation_definition_path(pipeline, harvest_definition, transformation_definition), params: {
           transformation_definition: {
-            name: 'copy'
+            name: transformation_definition.name
           }
         }
 
         follow_redirect!
 
-        expect(response.body).to include('Transformation Definition clone failed')
+        expect(response.body).to include('Transformation Definition clone failed. Please confirm that your Transformation Definition name is unique and then try again.')
       end
     end
   end

--- a/spec/requests/transformation_definitions_spec.rb
+++ b/spec/requests/transformation_definitions_spec.rb
@@ -201,14 +201,14 @@ RSpec.describe 'Transformation Definitions', type: :request do
 
   describe '#clone' do
     context 'when the clone is successful' do
-      it 'redirects to the Transformation Definition Edit page' do
+      it 'redirects to the Transformation Definition page' do
         post clone_pipeline_harvest_definition_transformation_definition_path(pipeline, harvest_definition, transformation_definition), params: {
           transformation_definition: {
             name: 'copy'
           }
         }
   
-        expect(response).to redirect_to edit_pipeline_harvest_definition_transformation_definition_path(pipeline, harvest_definition, TransformationDefinition.last)
+        expect(response).to redirect_to pipeline_harvest_definition_transformation_definition_path(pipeline, harvest_definition, TransformationDefinition.last)
       end
 
       it 'displays an appropriate message' do

--- a/spec/requests/transformation_definitions_spec.rb
+++ b/spec/requests/transformation_definitions_spec.rb
@@ -198,4 +198,58 @@ RSpec.describe 'Transformation Definitions', type: :request do
       end
     end
   end
+
+  describe '#clone' do
+    context 'when the clone is successful' do
+      it 'redirects to the Transformation Definition Edit page' do
+        post clone_pipeline_harvest_definition_transformation_definition_path(pipeline, harvest_definition, transformation_definition), params: {
+          transformation_definition: {
+            name: 'copy'
+          }
+        }
+  
+        expect(response).to redirect_to edit_pipeline_harvest_definition_transformation_definition_path(pipeline, harvest_definition, TransformationDefinition.last)
+      end
+
+      it 'displays an appropriate message' do
+        post clone_pipeline_harvest_definition_transformation_definition_path(pipeline, harvest_definition, transformation_definition), params: {
+          transformation_definition: {
+            name: 'copy'
+          }
+        }
+
+        follow_redirect!
+
+        expect(response.body).to include('Transformation Definition cloned successfully')
+      end
+    end
+
+    context 'when the clone fails' do
+      before do
+        allow_any_instance_of(TransformationDefinition).to receive(:clone).and_return false
+      end
+
+      it 'redirects to the Pipeline page' do
+        post clone_pipeline_harvest_definition_transformation_definition_path(pipeline, harvest_definition, transformation_definition), params: {
+          transformation_definition: {
+            name: 'copy'
+          }
+        }
+
+        expect(response).to redirect_to pipeline_path(pipeline)
+      end
+
+      it 'displays an appropriate message' do
+        post clone_pipeline_harvest_definition_transformation_definition_path(pipeline, harvest_definition, transformation_definition), params: {
+          transformation_definition: {
+            name: 'copy'
+          }
+        }
+
+        follow_redirect!
+
+        expect(response.body).to include('Transformation Definition clone failed')
+      end
+    end
+  end
 end


### PR DESCRIPTION
**Acceptance Criteria**
- User can create an exact copy of a shared definition that can be edited independently
- When user 'Creates new definition from shared' definition name is copied and prefaced with '[CLONE]'
- The new definition is no longer shared and has no association with old definition

**Notes**
- Consider how we can prep this functionality to be applied to entire pipelines

[Design concepts](https://www.figma.com/file/UL5rFpFs9woyHNBdspYu3C/SJ-%7C-Proof-of-Concept?type=design&node-id=4032%3A9047&mode=design&t=5BTlZM3xov8fzmNT-1)