### PR TITLE
SHARED DEFINITIONS (III ) DELETIONS: As Dan I want to be able to delete a definition from my pipeline so that I can easily replace it with another one.

### DIFF
--- a/app/controllers/extraction_definitions_controller.rb
+++ b/app/controllers/extraction_definitions_controller.rb
@@ -64,7 +64,8 @@ class ExtractionDefinitionsController < ApplicationController
     else
       flash.alert = t('.failure')
 
-      redirect_to pipeline_harvest_definition_extraction_definition_path(@pipeline, @harvest_definition, @extraction_definition)
+      redirect_to pipeline_harvest_definition_extraction_definition_path(@pipeline, @harvest_definition,
+                                                                         @extraction_definition)
     end
   end
 

--- a/app/controllers/extraction_definitions_controller.rb
+++ b/app/controllers/extraction_definitions_controller.rb
@@ -5,7 +5,7 @@ class ExtractionDefinitionsController < ApplicationController
 
   before_action :find_pipeline
   before_action :find_harvest_definition
-  before_action :find_extraction_definition, only: %i[show edit update clone]
+  before_action :find_extraction_definition, only: %i[show edit update clone destroy]
   before_action :find_destinations, only: %i[new create edit update]
 
   def show
@@ -63,7 +63,8 @@ class ExtractionDefinitionsController < ApplicationController
       redirect_to pipeline_path(@pipeline), notice: t('.success')
     else
       flash.alert = t('.failure')
-      redirect_to pipeline_extraction_definition_path(@pipeline, @extraction_definition)
+
+      redirect_to pipeline_harvest_definition_extraction_definition_path(@pipeline, @harvest_definition, @extraction_definition)
     end
   end
 

--- a/app/controllers/harvest_definitions_controller.rb
+++ b/app/controllers/harvest_definitions_controller.rb
@@ -4,7 +4,7 @@ class HarvestDefinitionsController < ApplicationController
   include LastEditedBy
 
   before_action :find_pipeline
-  before_action :find_harvest_definition, only: %i[update]
+  before_action :find_harvest_definition, only: %i[update destroy]
   before_action :find_destinations
 
   def create
@@ -32,11 +32,13 @@ class HarvestDefinitionsController < ApplicationController
   end
 
   def destroy
+    harvest_kind = @harvest_definition.kind.capitalize
+
     if @harvest_definition.destroy
       update_last_edited_by([@pipeline])
-      flash.notice = t('.success')
+      flash.notice = t('.success', kind: harvest_kind)
     else
-      flash.alert = t('.failure')
+      flash.alert = t('.failure', kind: harvest_kind)
     end
 
     redirect_to pipeline_path(@pipeline)

--- a/app/helpers/pipelines_helper.rb
+++ b/app/helpers/pipelines_helper.rb
@@ -15,6 +15,16 @@ module PipelinesHelper
     "Edit #{type}"
   end
 
+  def definition_delete_text(definition, type)
+    if definition.shared?
+      "<p>This will <strong>NOT</strong> delete the #{type} definition '#{definition.name}'
+          as it is shared with another pipeline.</p>"
+    else
+      "<p>This <strong>WILL</strong> delete the #{type} definition '#{definition.name}'
+          as it is <strong>NOT</strong> shared with another pipeline.</p>"
+    end
+  end
+
   private
 
   def extraction_definition_help_text(definition, type)

--- a/app/helpers/pipelines_helper.rb
+++ b/app/helpers/pipelines_helper.rb
@@ -16,15 +16,11 @@ module PipelinesHelper
   end
 
   def definition_delete_text(definition, type)
-    # rubocop:disable Rails/OutputSafety
     if definition.shared?
-      "<p>This will <strong>NOT</strong> delete the #{type} definition '#{definition.name}'
-          as it is shared with another pipeline.</p>".html_safe
+      "This will NOT delete the #{type} definition '#{definition.name}' as it is shared with another pipeline."
     else
-      "<p>This <strong>WILL</strong> delete the #{type} definition '#{definition.name}
-          as it is <strong>NOT</strong> shared with another pipeline.</p>".html_safe
+      "This WILL delete the #{type} definition '#{definition.name} as it is NOT shared with another pipeline."
     end
-    # rubocop:enable Rails/OutputSafety
   end
 
   private

--- a/app/helpers/pipelines_helper.rb
+++ b/app/helpers/pipelines_helper.rb
@@ -16,13 +16,15 @@ module PipelinesHelper
   end
 
   def definition_delete_text(definition, type)
+    # rubocop:disable Rails/OutputSafety
     if definition.shared?
       "<p>This will <strong>NOT</strong> delete the #{type} definition '#{definition.name}'
-          as it is shared with another pipeline.</p>"
+          as it is shared with another pipeline.</p>".html_safe
     else
-      "<p>This <strong>WILL</strong> delete the #{type} definition '#{definition.name}'
-          as it is <strong>NOT</strong> shared with another pipeline.</p>"
+      "<p>This <strong>WILL</strong> delete the #{type} definition '#{definition.name}
+          as it is <strong>NOT</strong> shared with another pipeline.</p>".html_safe
     end
+    # rubocop:enable Rails/OutputSafety
   end
 
   private

--- a/app/models/extraction_definition.rb
+++ b/app/models/extraction_definition.rb
@@ -9,8 +9,8 @@ class ExtractionDefinition < ApplicationRecord
   belongs_to :pipeline
   belongs_to :last_edited_by, class_name: 'User', optional: true
 
-  has_many :harvest_definitions, dependent: :restrict_with_exception
-  has_many :extraction_jobs, dependent: :restrict_with_exception
+  has_many :harvest_definitions, dependent: :nullify
+  has_many :extraction_jobs, dependent: :destroy
   has_many :requests, dependent: :destroy
   has_many :parameters, through: :requests
   validates :name, uniqueness: true

--- a/app/models/pipeline.rb
+++ b/app/models/pipeline.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Pipeline < ApplicationRecord
-  has_many :harvest_definitions, dependent: :restrict_with_exception
+  has_many :harvest_definitions, dependent: :destroy
   has_many :harvest_jobs, through: :harvest_definitions
   belongs_to :last_edited_by, class_name: 'User', optional: true
 

--- a/app/models/transformation_definition.rb
+++ b/app/models/transformation_definition.rb
@@ -5,7 +5,7 @@ class TransformationDefinition < ApplicationRecord
   belongs_to :pipeline
   belongs_to :last_edited_by, class_name: 'User', optional: true
 
-  has_many :harvest_definitions, dependent: :restrict_with_exception
+  has_many :harvest_definitions, dependent: :nullify
   has_many :fields, dependent: :destroy
   enum :kind, { harvest: 0, enrichment: 1 }
 

--- a/app/views/extraction_definitions/show.html.erb
+++ b/app/views/extraction_definitions/show.html.erb
@@ -13,7 +13,7 @@
             @pipeline, @harvest_definition, @extraction_definition
           ),
           class: 'btn btn-outline-primary'
-      ) do %>
+        ) do %>
       <i class="bi bi-pencil-square" aria-hidden="true"></i> Edit
     <% end %>
     <button type="button" class="btn btn-outline-danger" data-bs-toggle="modal" data-bs-target="#delete-modal">
@@ -28,12 +28,14 @@
 
 <div id="js-extraction-app" data-props="<%= @props %>"></div>
 
-<%= render layout: 'shared/delete_modal', locals: { path: pipeline_harvest_definition_extraction_definition_path(@pipeline, @harvest_definition, @extraction_definition) } do %>
+<%= render layout: 'shared/delete_modal',
+           locals: { path: pipeline_harvest_definition_extraction_definition_path(@pipeline, @harvest_definition,
+                                                                                  @extraction_definition) } do %>
   <p>
     Are you sure you want to delete "<%= @extraction_definition.name %>"?
   </p>
 
-  <p> 
+  <p>
     This will also delete the extracted data associated with it.
   </p>
 <% end %>

--- a/app/views/extraction_definitions/show.html.erb
+++ b/app/views/extraction_definitions/show.html.erb
@@ -13,7 +13,7 @@
             @pipeline, @harvest_definition, @extraction_definition
           ),
           class: 'btn btn-outline-primary'
-        ) do %>
+      ) do %>
       <i class="bi bi-pencil-square" aria-hidden="true"></i> Edit
     <% end %>
     <button type="button" class="btn btn-outline-danger" data-bs-toggle="modal" data-bs-target="#delete-modal">
@@ -27,3 +27,13 @@
 <% end %>
 
 <div id="js-extraction-app" data-props="<%= @props %>"></div>
+
+<%= render layout: 'shared/delete_modal', locals: { path: pipeline_harvest_definition_extraction_definition_path(@pipeline, @harvest_definition, @extraction_definition) } do %>
+  <p>
+    Are you sure you want to delete "<%= @extraction_definition.name %>"?
+  </p>
+
+  <p> 
+    This will also delete the extracted data associated with it.
+  </p>
+<% end %>

--- a/app/views/pipelines/_card.html.erb
+++ b/app/views/pipelines/_card.html.erb
@@ -34,17 +34,18 @@
                 <i class="bi bi-layers me-2"></i>Clone and edit new definition
               </a>
           </li>
-        <% end %>
 
-        <li>
-          <a
-            class="dropdown-item card__control-action"
-            href="#"
-            data-bs-toggle='modal'
-            data-bs-target="<%= "#remove-reference-#{definition.id}" %>">
-              <i class="bi bi-trash me-2"></i>Remove definition
-            </a>
-        </li>
+        
+          <li>
+            <a
+              class="dropdown-item card__control-action"
+              href="#"
+              data-bs-toggle='modal'
+              data-bs-target="<%= "#remove-shared-#{type}-definition-#{definition.id}" %>">
+                <i class="bi bi-trash me-2"></i>Remove shared definition
+              </a>
+          </li>
+        <% end %>
 
         <% if jobs_path.present? %>
           <li>
@@ -80,15 +81,15 @@
 
 <div
   class="modal fade"
-  id="<%= "remove-reference-#{type}-#{definition.id}" %>">
+  id="<%= "remove-shared-#{type}-definition-#{definition.id}" %>">
   <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title">Remove reference</h5>
+        <h5 class="modal-title">Remove shared definition</h5>
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
       </div>
       <div class="modal-body">
-        <p>Are you sure you want to remove this reference?</p>
+        <p>Are you sure you want to remove this shared definition?</p>
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>

--- a/app/views/pipelines/_card.html.erb
+++ b/app/views/pipelines/_card.html.erb
@@ -35,7 +35,6 @@
               </a>
           </li>
 
-        
           <li>
             <a
               class="dropdown-item card__control-action"
@@ -43,6 +42,16 @@
               data-bs-toggle='modal'
               data-bs-target="<%= "#remove-shared-#{type}-definition-#{definition.id}" %>">
                 <i class="bi bi-trash me-2"></i>Remove shared definition
+              </a>
+          </li>
+        <% else %>
+          <li>
+            <a
+              class="dropdown-item card__control-action"
+              href="#"
+              data-bs-toggle='modal'
+              data-bs-target="<%= "#delete-#{type}-definition-#{definition.id}" %>">
+                <i class="bi bi-trash me-2"></i>Delete definition
               </a>
           </li>
         <% end %>
@@ -105,6 +114,11 @@
     </div>
   </div>
 </div>
+
+<%= render layout: 'shared/delete_modal', locals: { path: '', id: "delete-#{type}-definition-#{definition.id}" } do %>
+  <p>Are you sure you want to delete this definition?</p>
+  <p>It will also delete all the data associated with it.</p>
+<% end %>
 
 <div
   class="modal fade"

--- a/app/views/pipelines/_card.html.erb
+++ b/app/views/pipelines/_card.html.erb
@@ -2,6 +2,7 @@
    run_sample_extraction_path ||= ''
    run_full_extraction_path ||= ''
    type = definition.class.name.gsub(/Definition$/, '').downcase
+   delete_path ||= ''
    position = type == 'extraction' ? 'first' : 'last' %>
 
 <div class="card">
@@ -115,9 +116,14 @@
   </div>
 </div>
 
-<%= render layout: 'shared/delete_modal', locals: { path: '', id: "delete-#{type}-definition-#{definition.id}" } do %>
-  <p>Are you sure you want to delete this definition?</p>
-  <p>It will also delete all the data associated with it.</p>
+<%= render layout: 'shared/delete_modal', locals: { path: delete_path, id: "delete-#{type}-definition-#{definition.id}", heading_text: "Delete #{type.capitalize} definition" } do %>
+  <p>Are you sure you want to delete "<%= definition.name %>"?</p>
+
+  <% if type == 'transformation' %>
+    <p>This will also delete all the fields associated with it.</p>
+  <% else %>
+    <p>This will also delete the extracted data associated with it.</p>
+  <% end %>
 <% end %>
 
 <div

--- a/app/views/pipelines/_card.html.erb
+++ b/app/views/pipelines/_card.html.erb
@@ -116,7 +116,9 @@
   </div>
 </div>
 
-<%= render layout: 'shared/delete_modal', locals: { path: delete_path, id: "delete-#{type}-definition-#{definition.id}", heading_text: "Delete #{type.capitalize} definition" } do %>
+<%= render layout: 'shared/delete_modal',
+           locals: { path: delete_path, id: "delete-#{type}-definition-#{definition.id}",
+                     heading_text: "Delete #{type.capitalize} definition" } do %>
   <p>Are you sure you want to delete "<%= definition.name %>"?</p>
 
   <% if type == 'transformation' %>

--- a/app/views/pipelines/show.html.erb
+++ b/app/views/pipelines/show.html.erb
@@ -260,6 +260,12 @@
                 @harvest_definition,
                 @harvest_definition.extraction_definition,
                 kind: :full
+              ),
+                      delete_path:
+              pipeline_harvest_definition_extraction_definition_path(
+                @pipeline,
+                @harvest_definition,
+                @harvest_definition.extraction_definition
               )
                      } %>
 
@@ -292,7 +298,13 @@
                 @harvest_definition.transformation_definition
               ),
                        edit_text: definition_edit_text(@harvest_definition.transformation_definition, 'transformation'),
-                       jobs_path: ''
+                       jobs_path: '',
+                       delete_path:
+                pipeline_harvest_definition_transformation_definition_path(
+                  @pipeline,
+                  @harvest_definition,
+                  @harvest_definition.transformation_definition
+                )
                      } %>
 
         <% else %>
@@ -414,7 +426,13 @@
                   enrichment_definition,
                   enrichment_definition.extraction_definition,
                   kind: :full
-                )
+                ),
+                                      delete_path:
+              pipeline_harvest_definition_extraction_definition_path(
+                @pipeline,
+                enrichment_definition,
+                enrichment_definition.extraction_definition
+              )
                      } %>
 
           <% else %>
@@ -483,7 +501,13 @@
                 ),
                        edit_text: definition_edit_text(enrichment_definition.transformation_definition,
                                                        'transformation'),
-                       jobs_path: ''
+                       jobs_path: '',
+                       delete_path:
+                        pipeline_harvest_definition_transformation_definition_path(
+                          @pipeline,
+                          enrichment_definition,
+                          enrichment_definition.transformation_definition
+                        )
                      } %>
 
           <% else %>

--- a/app/views/pipelines/show.html.erb
+++ b/app/views/pipelines/show.html.erb
@@ -185,7 +185,35 @@
           data-bs-target="#edit-harvest">
           <i class="bi bi-pencil-square" aria-hidden="true"></i> Edit Harvest
         </button>
+
+        <button
+          type="button"
+          class="btn btn-outline-danger"
+          data-bs-toggle="modal"
+          data-bs-target="<%= "#delete-harvest-definition-#{@harvest_definition.id}" %>">
+          <i class="bi bi-trash" aria-hidden="true"></i> Delete Harvest
+        </button>
       </div>
+
+      <%= render layout: 'shared/delete_modal', locals: { path: pipeline_harvest_definition_path(@pipeline, @harvest_definition), id: "delete-harvest-definition-#{@harvest_definition.id}", heading_text: "Delete Harvest" } do %>
+        <p>Are you sure you want to delete "<%= @harvest_definition.source_id %>"?</p>
+
+        <% if @harvest_definition.extraction_definition.present? %>
+          <% if @harvest_definition.extraction_definition.shared? %>
+            <p>This will <strong>NOT</strong> delete the extraction definition "<%= @harvest_definition.extraction_definition.name %>" as it is shared with another pipeline.</p>
+          <% else %>
+            <p>This <strong>WILL</strong> delete the extraction definition "<%= @harvest_definition.extraction_definition.name %>" as it is not shared with another pipeline.</p>
+          <% end %>
+        <% end %>
+
+        <% if @harvest_definition.transformation_definition.present? %>
+          <% if @harvest_definition.transformation_definition.shared? %>
+            <p>This will <strong>NOT</strong> delete the transformation definition "<%= @harvest_definition.transformation_definition.name %>" as it is shared with another pipeline.</p>
+          <% else %>
+            <p>This <strong>WILL</strong> delete the transformation definition "<%= @harvest_definition.transformation_definition.name %>" as it is not shared with another pipeline.</p>
+          <% end %>
+        <% end %>
+      <% end %>
 
       <%= render layout: 'shared/create_modal', locals: { modal_heading: 'Edit harvest', id: 'edit-harvest' } do %>
         <div class='d-grid mt-4'>
@@ -349,7 +377,35 @@
             data-bs-target="<%= "#edit-enrichment-#{enrichment_definition.id}" %>">
             <i class="bi bi-pencil-square" aria-hidden="true"></i> Edit Enrichment
           </button>
+
+          <button
+            type="button"
+            class="btn btn-outline-danger"
+            data-bs-toggle="modal"
+            data-bs-target="<%= "#delete-harvest-definition-#{enrichment_definition.id}" %>">
+            <i class="bi bi-trash" aria-hidden="true"></i> Delete Enrichment
+          </button>
         </div>
+
+        <%= render layout: 'shared/delete_modal', locals: { path: pipeline_harvest_definition_path(@pipeline, enrichment_definition), id: "delete-harvest-definition-#{enrichment_definition.id}", heading_text: "Delete Enrichment" } do %>
+          <p>Are you sure you want to delete "<%= enrichment_definition.source_id %>"?</p>
+
+          <% if enrichment_definition.extraction_definition.present? %>
+            <% if enrichment_definition.extraction_definition.shared? %>
+              <p>This will <strong>NOT</strong> delete the extraction definition "<%= enrichment_definition.extraction_definition.name %>" as it is shared with another pipeline.</p>
+            <% else %>
+              <p>This <strong>WILL</strong> delete the extraction definition "<%= enrichment_definition.extraction_definition.name %>" as it is not shared with another pipeline.</p>
+            <% end %>
+          <% end %>
+
+          <% if enrichment_definition.transformation_definition.present? %>
+            <% if enrichment_definition.transformation_definition.shared? %>
+              <p>This will <strong>NOT</strong> delete the transformation definition "<%= enrichment_definition.transformation_definition.name %>" as it is shared with another pipeline.</p>
+            <% else %>
+              <p>This <strong>WILL</strong> delete the transformation definition "<%= enrichment_definition.transformation_definition.name %>" as it is not shared with another pipeline.</p>
+            <% end %>
+          <% end %>
+        <% end %>
 
         <%= render layout: 'shared/create_modal',
                    locals: { modal_heading: 'Edit enrichment',
@@ -496,7 +552,7 @@
                        edit_path:
                 pipeline_harvest_definition_transformation_definition_path(
                   @pipeline,
-                  @harvest_definition,
+                  enrichment_definition,
                   enrichment_definition.transformation_definition
                 ),
                        edit_text: definition_edit_text(enrichment_definition.transformation_definition,

--- a/app/views/pipelines/show.html.erb
+++ b/app/views/pipelines/show.html.erb
@@ -202,11 +202,11 @@
           <p>Are you sure you want to delete "<%= @harvest_definition.source_id %>"?</p>
 
           <% if @harvest_definition.extraction_definition.present? %>
-            <%= definition_delete_text(@harvest_definition.extraction_definition, 'extraction') %>
+            <p><%= definition_delete_text(@harvest_definition.extraction_definition, 'extraction') %></p>
           <% end %>
 
           <% if @harvest_definition.transformation_definition.present? %>
-            <%= definition_delete_text(@harvest_definition.transformation_definition, 'transformation') %>
+            <p><%= definition_delete_text(@harvest_definition.transformation_definition, 'transformation') %></p>
           <% end %>
         <% end %>
       <% end %>
@@ -390,11 +390,11 @@
           <p>Are you sure you want to delete "<%= enrichment_definition.source_id %>"?</p>
 
           <% if enrichment_definition.extraction_definition.present? %>
-            <%= definition_delete_text(enrichment_definition.extraction_definition, 'extraction') %>
+            <p><%= definition_delete_text(enrichment_definition.extraction_definition, 'extraction') %></p>
           <% end %>
 
           <% if enrichment_definition.transformation_definition.present? %>
-            <%= definition_delete_text(enrichment_definition.transformation_definition, 'transformation') %>
+            <p><%= definition_delete_text(enrichment_definition.transformation_definition, 'transformation') %></p>
           <% end %>
         <% end %>
 
@@ -630,11 +630,11 @@
 
   <% @pipeline.harvest_definitions.each do |definition| %>
     <% if definition.extraction_definition.present? %>
-      <%= definition_delete_text(definition.extraction_definition, 'extraction') %>
+      <p><%= definition_delete_text(definition.extraction_definition, 'extraction') %></p>
     <% end %>
 
     <% if definition.transformation_definition.present? %>
-      <%= definition_delete_text(definition.transformation_definition, 'transformation') %>
+      <p><%= definition_delete_text(definition.transformation_definition, 'transformation') %></p>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/pipelines/show.html.erb
+++ b/app/views/pipelines/show.html.erb
@@ -199,19 +199,11 @@
         <p>Are you sure you want to delete "<%= @harvest_definition.source_id %>"?</p>
 
         <% if @harvest_definition.extraction_definition.present? %>
-          <% if @harvest_definition.extraction_definition.shared? %>
-            <p>This will <strong>NOT</strong> delete the extraction definition "<%= @harvest_definition.extraction_definition.name %>" as it is shared with another pipeline.</p>
-          <% else %>
-            <p>This <strong>WILL</strong> delete the extraction definition "<%= @harvest_definition.extraction_definition.name %>" as it is not shared with another pipeline.</p>
-          <% end %>
+          <%= definition_delete_text(@harvest_definition.extraction_definition, 'extraction').html_safe %>
         <% end %>
 
         <% if @harvest_definition.transformation_definition.present? %>
-          <% if @harvest_definition.transformation_definition.shared? %>
-            <p>This will <strong>NOT</strong> delete the transformation definition "<%= @harvest_definition.transformation_definition.name %>" as it is shared with another pipeline.</p>
-          <% else %>
-            <p>This <strong>WILL</strong> delete the transformation definition "<%= @harvest_definition.transformation_definition.name %>" as it is not shared with another pipeline.</p>
-          <% end %>
+          <%= definition_delete_text(@harvest_definition.transformation_definition, 'transformation').html_safe %>
         <% end %>
       <% end %>
 
@@ -391,19 +383,11 @@
           <p>Are you sure you want to delete "<%= enrichment_definition.source_id %>"?</p>
 
           <% if enrichment_definition.extraction_definition.present? %>
-            <% if enrichment_definition.extraction_definition.shared? %>
-              <p>This will <strong>NOT</strong> delete the extraction definition "<%= enrichment_definition.extraction_definition.name %>" as it is shared with another pipeline.</p>
-            <% else %>
-              <p>This <strong>WILL</strong> delete the extraction definition "<%= enrichment_definition.extraction_definition.name %>" as it is not shared with another pipeline.</p>
-            <% end %>
+            <%= definition_delete_text(enrichment_definition.extraction_definition, 'extraction').html_safe %>
           <% end %>
 
           <% if enrichment_definition.transformation_definition.present? %>
-            <% if enrichment_definition.transformation_definition.shared? %>
-              <p>This will <strong>NOT</strong> delete the transformation definition "<%= enrichment_definition.transformation_definition.name %>" as it is shared with another pipeline.</p>
-            <% else %>
-              <p>This <strong>WILL</strong> delete the transformation definition "<%= enrichment_definition.transformation_definition.name %>" as it is not shared with another pipeline.</p>
-            <% end %>
+            <%= definition_delete_text(enrichment_definition.transformation_definition, 'transformation').html_safe %>
           <% end %>
         <% end %>
 
@@ -634,8 +618,19 @@
 
 <%# -- Modals -- %>
 
-<%= render layout: 'shared/delete_modal', locals: { path: pipeline_path(@pipeline) } do %>
-  Are you sure you want to delete "<%= @pipeline.name %>"?
+<%= render layout: 'shared/delete_modal', locals: { path: pipeline_path(@pipeline), heading_text: "Delete Pipeline" } do %>
+  <p>Are you sure you want to delete "<%= @pipeline.name %>"?</p>
+
+
+  <% @pipeline.harvest_definitions.each do |definition| %>
+    <% if definition.extraction_definition.present? %>
+      <%= definition_delete_text(definition.extraction_definition, 'extraction').html_safe %>
+    <% end %>
+
+    <% if definition.transformation_definition.present? %>
+      <%= definition_delete_text(definition.transformation_definition, 'transformation').html_safe %>
+    <% end %>
+  <% end %>
 <% end %>
 
 <%= render layout: 'shared/create_modal',

--- a/app/views/pipelines/show.html.erb
+++ b/app/views/pipelines/show.html.erb
@@ -195,15 +195,19 @@
         </button>
       </div>
 
-      <%= render layout: 'shared/delete_modal', locals: { path: pipeline_harvest_definition_path(@pipeline, @harvest_definition), id: "delete-harvest-definition-#{@harvest_definition.id}", heading_text: "Delete Harvest" } do %>
-        <p>Are you sure you want to delete "<%= @harvest_definition.source_id %>"?</p>
+      <% if @harvest_definition.persisted? %>
+        <%= render layout: 'shared/delete_modal',
+                   locals: { path: pipeline_harvest_definition_path(@pipeline, @harvest_definition),
+                             id: "delete-harvest-definition-#{@harvest_definition.id}", heading_text: 'Delete Harvest' } do %>
+          <p>Are you sure you want to delete "<%= @harvest_definition.source_id %>"?</p>
 
-        <% if @harvest_definition.extraction_definition.present? %>
-          <%= definition_delete_text(@harvest_definition.extraction_definition, 'extraction').html_safe %>
-        <% end %>
+          <% if @harvest_definition.extraction_definition.present? %>
+            <%= definition_delete_text(@harvest_definition.extraction_definition, 'extraction') %>
+          <% end %>
 
-        <% if @harvest_definition.transformation_definition.present? %>
-          <%= definition_delete_text(@harvest_definition.transformation_definition, 'transformation').html_safe %>
+          <% if @harvest_definition.transformation_definition.present? %>
+            <%= definition_delete_text(@harvest_definition.transformation_definition, 'transformation') %>
+          <% end %>
         <% end %>
       <% end %>
 
@@ -281,7 +285,7 @@
                 @harvest_definition.extraction_definition,
                 kind: :full
               ),
-                      delete_path:
+                       delete_path:
               pipeline_harvest_definition_extraction_definition_path(
                 @pipeline,
                 @harvest_definition,
@@ -379,15 +383,18 @@
           </button>
         </div>
 
-        <%= render layout: 'shared/delete_modal', locals: { path: pipeline_harvest_definition_path(@pipeline, enrichment_definition), id: "delete-harvest-definition-#{enrichment_definition.id}", heading_text: "Delete Enrichment" } do %>
+        <%= render layout: 'shared/delete_modal',
+                   locals: { path: pipeline_harvest_definition_path(@pipeline, enrichment_definition),
+                             id: "delete-harvest-definition-#{enrichment_definition.id}",
+                             heading_text: 'Delete Enrichment' } do %>
           <p>Are you sure you want to delete "<%= enrichment_definition.source_id %>"?</p>
 
           <% if enrichment_definition.extraction_definition.present? %>
-            <%= definition_delete_text(enrichment_definition.extraction_definition, 'extraction').html_safe %>
+            <%= definition_delete_text(enrichment_definition.extraction_definition, 'extraction') %>
           <% end %>
 
           <% if enrichment_definition.transformation_definition.present? %>
-            <%= definition_delete_text(enrichment_definition.transformation_definition, 'transformation').html_safe %>
+            <%= definition_delete_text(enrichment_definition.transformation_definition, 'transformation') %>
           <% end %>
         <% end %>
 
@@ -467,7 +474,7 @@
                   enrichment_definition.extraction_definition,
                   kind: :full
                 ),
-                                      delete_path:
+                       delete_path:
               pipeline_harvest_definition_extraction_definition_path(
                 @pipeline,
                 enrichment_definition,
@@ -618,17 +625,16 @@
 
 <%# -- Modals -- %>
 
-<%= render layout: 'shared/delete_modal', locals: { path: pipeline_path(@pipeline), heading_text: "Delete Pipeline" } do %>
+<%= render layout: 'shared/delete_modal', locals: { path: pipeline_path(@pipeline), heading_text: 'Delete Pipeline' } do %>
   <p>Are you sure you want to delete "<%= @pipeline.name %>"?</p>
-
 
   <% @pipeline.harvest_definitions.each do |definition| %>
     <% if definition.extraction_definition.present? %>
-      <%= definition_delete_text(definition.extraction_definition, 'extraction').html_safe %>
+      <%= definition_delete_text(definition.extraction_definition, 'extraction') %>
     <% end %>
 
     <% if definition.transformation_definition.present? %>
-      <%= definition_delete_text(definition.transformation_definition, 'transformation').html_safe %>
+      <%= definition_delete_text(definition.transformation_definition, 'transformation') %>
     <% end %>
   <% end %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -73,6 +73,9 @@ en:
     update:
       success: Harvest Definition updated successfully
       failure: There was an issue updating your Harvest Definition
+    destroy:
+      success: "%{kind} deleted successfully"
+      failure: "There was an issue deleting your %{kind}"
 
   harvest_jobs:
     create:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,7 +26,7 @@ Rails.application.routes.draw do
     end
 
     resources :harvest_definitions, only: %i[create update] do
-      resources :extraction_definitions, only: %i[show edit new create update] do
+      resources :extraction_definitions, only: %i[show edit new create update destroy] do
         collection do
           post :test
           post :test_record_extraction

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,7 +25,7 @@ Rails.application.routes.draw do
       post :cancel, on: :member
     end
 
-    resources :harvest_definitions, only: %i[create update] do
+    resources :harvest_definitions, only: %i[create update destroy] do
       resources :extraction_definitions, only: %i[show edit new create update destroy] do
         collection do
           post :test

--- a/spec/models/harvest_definition_spec.rb
+++ b/spec/models/harvest_definition_spec.rb
@@ -122,4 +122,35 @@ RSpec.describe HarvestDefinition, type: :model do
       expect(cloned_harvest_definition.transformation_definition).to eq harvest_definition.transformation_definition
     end
   end
+
+  describe "#destroy" do
+    let(:pipeline)                  { create(:pipeline)}
+    let!(:harvest_definition)       { create(:harvest_definition, pipeline:, extraction_definition:, transformation_definition:) }
+    let(:extraction_definition)     { create(:extraction_definition) }
+    let(:transformation_definition) { create(:transformation_definition) }
+
+    context 'when the associated Extraction Definition and Transformation Definition were not shared' do
+      it 'destroys the Extraction Definition' do
+       expect { harvest_definition.destroy }.to change(ExtractionDefinition, :count).by(-1) 
+      end
+
+      it 'destroys the Transformation Definition' do
+        expect { harvest_definition.destroy }.to change(TransformationDefinition, :count).by(-1)
+      end
+    end
+
+    context 'when the associated Extraction Definition and Transformation Definition were shared' do
+      let!(:harvest_definition_two) { create(:harvest_definition, pipeline:, extraction_definition:, transformation_definition:) }
+      
+      it 'does not destroy the Extraction Definition' do
+        expect(extraction_definition.shared?).to eq true 
+        expect { harvest_definition.destroy }.to change(ExtractionDefinition, :count).by(0)
+      end
+
+      it 'does not destroy the Transformation Definition' do
+        expect(transformation_definition.shared?).to eq true
+        expect { harvest_definition.destroy }.to change(TransformationDefinition, :count).by(0)
+      end
+    end
+  end
 end

--- a/spec/requests/extraction_definitions_spec.rb
+++ b/spec/requests/extraction_definitions_spec.rb
@@ -256,4 +256,57 @@ RSpec.describe 'ExtractionDefinitions', type: :request do
       end
     end
   end
+
+  describe '#destroy' do
+    let!(:request_one)              { create(:request, :figshare_initial_request, extraction_definition:) }
+    let!(:request_two)              { create(:request, :figshare_main_request, extraction_definition:) }
+
+    context 'when the deletion is successful' do
+      it 'destroys the Extraction Definition' do
+        expect do
+          delete pipeline_harvest_definition_extraction_definition_path(pipeline, harvest_definition, extraction_definition)
+        end.to change(ExtractionDefinition, :count).by(-1)
+      end
+
+      it 'redirects to the pipeline path' do
+        delete pipeline_harvest_definition_extraction_definition_path(pipeline, harvest_definition, extraction_definition)
+  
+        expect(response).to redirect_to(pipeline_path(pipeline))
+      end
+  
+      it 'displays an appropriate message' do
+        delete pipeline_harvest_definition_extraction_definition_path(pipeline, harvest_definition, extraction_definition)
+
+        follow_redirect!
+
+        expect(response.body).to include('Extraction Definition deleted successfully')
+      end
+    end
+
+    context 'when the deletion is unsuccessful' do
+      before do
+        allow_any_instance_of(ExtractionDefinition).to receive(:destroy).and_return(false)
+      end
+
+      it 'does not destroy the Extraction Definition' do
+        expect do
+          delete pipeline_harvest_definition_extraction_definition_path(pipeline, harvest_definition, extraction_definition)
+        end.to change(ExtractionDefinition, :count).by(0)
+      end
+
+      it 'redirects to the Extraction Definition path' do
+        delete pipeline_harvest_definition_extraction_definition_path(pipeline, harvest_definition, extraction_definition)
+  
+        expect(response).to redirect_to(pipeline_harvest_definition_extraction_definition_path(pipeline, harvest_definition, extraction_definition))
+      end
+
+      it 'displays an appropriate message' do
+        delete pipeline_harvest_definition_extraction_definition_path(pipeline, harvest_definition, extraction_definition)
+
+        follow_redirect!
+
+        expect(response.body).to include('There was an issue deleting your Extraction Definition')
+      end
+    end
+  end
 end

--- a/spec/requests/harvest_definitions_spec.rb
+++ b/spec/requests/harvest_definitions_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'HarvestDefinitions', type: :request do
   let(:extraction_job)            { create(:extraction_job, extraction_definition:) }
   let(:transformation_definition) { create(:transformation_definition, extraction_job:) }
   let(:destination)               { create(:destination) }
-  let(:harvest_definition)        { create(:harvest_definition) }
+  let!(:harvest_definition)        { create(:harvest_definition, pipeline:) }
 
   before do
     sign_in user
@@ -127,6 +127,56 @@ RSpec.describe 'HarvestDefinitions', type: :request do
         harvest_definition.reload
 
         expect(harvest_definition.source_id).not_to eq nil
+      end
+    end
+  end
+
+  describe 'DELETE /destroy' do
+    context 'when the deletion is successful' do
+      it 'deletes the Harvest Definition' do
+        expect do
+         delete pipeline_harvest_definition_path(pipeline, harvest_definition) 
+        end.to change(HarvestDefinition, :count).by(-1)
+      end
+
+      it 'redirects to the Pipeline path' do
+        delete pipeline_harvest_definition_path(pipeline, harvest_definition)
+
+        expect(response).to redirect_to pipeline_path(pipeline)
+      end
+
+      it 'displays an appropriate message' do
+        delete pipeline_harvest_definition_path(pipeline, harvest_definition)
+
+        follow_redirect!
+        
+        expect(response.body).to include 'Harvest deleted successfully'
+      end
+    end
+
+    context 'when the deletion is not successful' do
+      before do
+        allow_any_instance_of(HarvestDefinition).to receive(:destroy).and_return(false)
+      end
+
+      it 'does not delete the Harvest Definition' do
+        expect do
+          delete pipeline_harvest_definition_path(pipeline, harvest_definition) 
+         end.to change(HarvestDefinition, :count).by(0) 
+      end
+
+      it 'redirects to the Pipeline path' do
+        delete pipeline_harvest_definition_path(pipeline, harvest_definition)
+
+        expect(response).to redirect_to pipeline_path(pipeline)
+      end
+
+      it 'displays an appropriate message' do
+        delete pipeline_harvest_definition_path(pipeline, harvest_definition)
+
+        follow_redirect!
+        
+        expect(response.body).to include 'There was an issue deleting your Harvest'
       end
     end
   end

--- a/spec/requests/transformation_definitions_spec.rb
+++ b/spec/requests/transformation_definitions_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'Transformation Definitions', type: :request do
   let!(:pipeline) { create(:pipeline) }
   let!(:harvest_definition) { create(:harvest_definition, pipeline:) }
   let(:extraction_job)            { create(:extraction_job) }
-  let(:transformation_definition) { create(:transformation_definition, extraction_job:) }
+  let!(:transformation_definition) { create(:transformation_definition, extraction_job:) }
 
   before do
     sign_in user
@@ -148,22 +148,43 @@ RSpec.describe 'Transformation Definitions', type: :request do
   end
 
   describe '#destroy' do
-    it 'destroys the transformation_definition' do
-      delete pipeline_harvest_definition_transformation_definition_path(pipeline, harvest_definition,
-                                                                        transformation_definition)
+    context 'when the deletion is successful' do
+      it 'deletes the Extraction Definition' do
+        expect do
+          delete pipeline_harvest_definition_transformation_definition_path(pipeline, harvest_definition,
+            transformation_definition)
+        end.to change(TransformationDefinition, :count).by(-1)
+      end
 
-      expect(response).to redirect_to(pipeline_path(pipeline))
-      follow_redirect!
-      expect(response.body).to include('Transformation Definition deleted successfully')
+      it 'redirects to the pipeline page' do
+        delete pipeline_harvest_definition_transformation_definition_path(pipeline, harvest_definition,
+                                                                          transformation_definition)
+  
+        expect(response).to redirect_to(pipeline_path(pipeline))
+        follow_redirect!
+        expect(response.body).to include('Transformation Definition deleted successfully')
+      end
     end
 
-    it 'displays a message when failing' do
-      allow_any_instance_of(TransformationDefinition).to receive(:destroy).and_return false
-      delete pipeline_harvest_definition_transformation_definition_path(pipeline, harvest_definition,
-                                                                        transformation_definition)
-      follow_redirect!
+    context 'when the deletion is not successful' do
+      before do
+        allow_any_instance_of(TransformationDefinition).to receive(:destroy).and_return(false)
+      end
 
-      expect(response.body).to include('There was an issue deleting your Transformation Definition')
+      it 'does not delete the Transformation Definition' do
+        expect do
+          delete pipeline_harvest_definition_transformation_definition_path(pipeline, harvest_definition,
+            transformation_definition)
+        end.to change(TransformationDefinition, :count).by(0) 
+      end
+
+      it 'displays an appropriate message' do
+        delete pipeline_harvest_definition_transformation_definition_path(pipeline, harvest_definition,
+                                                                          transformation_definition)
+        follow_redirect!
+  
+        expect(response.body).to include('There was an issue deleting your Transformation Definition')
+      end
     end
   end
 


### PR DESCRIPTION
**Acceptance Criteria**
- User can delete/remove a definition from a pipeline
 - If a definition is used in more than one pipeline: "Remove shared definition"
 - If a definition is only used in this pipeline: "Delete definition"
with a warning "Are you sure? This cannot be undone"
- Definition is not dependent on its original pipeline
- User can delete a block from a pipeline (deletion logic applies as above to definitions in block).
- Clean up any existing orphaned/lost/dud definitions

**Risks**
- Permanently deleting something that we want back

**Notes**
[Design concepts](https://www.figma.com/file/UL5rFpFs9woyHNBdspYu3C/SJ-%7C-Proof-of-Concept?type=design&node-id=4032%3A9046&mode=design&t=VYF6RIYc1rfes19X-1)

**Impacts**
- Really looking forward to being able to delete/remove stuff!!