### PR TITLE
IMPROVE PIPELINE LIST PAGE: As Tim, I want to be able to search across Pipelines, so I can find examples and get where I need to go as easily as possible. 

### DIFF
--- a/app/controllers/concerns/user_authorization.rb
+++ b/app/controllers/concerns/user_authorization.rb
@@ -14,6 +14,7 @@ module UserAuthorization
     excluded_paths = ['/users/sign_in', '/users/sign_out', '/users/password/new', '/users/invitation',
                       '/users/invitation/accept']
 
+    return if current_user.blank?
     return if excluded_paths.include?(request.path)
     return unless current_user.enforce_two_factor?
     return if current_user.two_factor_setup?

--- a/app/controllers/pipelines_controller.rb
+++ b/app/controllers/pipelines_controller.rb
@@ -78,7 +78,7 @@ class PipelinesController < ApplicationController
   end
 
   def pipelines
-    Pipeline.search(params[:search], params[:format]).order(sort_by).page(params[:page])
+    PipelineSearchQuery.new(params).call.order(sort_by).page(params[:page])
   end
 
   def sort_by

--- a/app/controllers/pipelines_controller.rb
+++ b/app/controllers/pipelines_controller.rb
@@ -78,7 +78,11 @@ class PipelinesController < ApplicationController
   end
 
   def pipelines
-    Pipeline.search(params[:search]).order(sort_by).page(params[:page])
+    Pipeline.search(params[:search], format).order(sort_by).page(params[:page])
+  end
+
+  def format
+    @format ||= params['format']
   end
 
   def sort_by

--- a/app/controllers/pipelines_controller.rb
+++ b/app/controllers/pipelines_controller.rb
@@ -78,11 +78,7 @@ class PipelinesController < ApplicationController
   end
 
   def pipelines
-    Pipeline.search(params[:search], format).order(sort_by).page(params[:page])
-  end
-
-  def format
-    @format ||= params['format']
+    Pipeline.search(params[:search], params[:format]).order(sort_by).page(params[:page])
   end
 
   def sort_by

--- a/app/controllers/pipelines_controller.rb
+++ b/app/controllers/pipelines_controller.rb
@@ -3,11 +3,10 @@
 class PipelinesController < ApplicationController
   include LastEditedBy
 
-  before_action :assign_sort_by, only: %w[index create]
   before_action :find_pipeline, only: %w[show destroy edit update clone]
 
   def index
-    @pipelines = Pipeline.order(@sort_by).page(params[:page])
+    @pipelines = pipelines
     @pipeline = Pipeline.new
   end
 
@@ -33,7 +32,7 @@ class PipelinesController < ApplicationController
       redirect_to pipeline_path(@pipeline), notice: t('.success')
     else
       flash.alert = t('.failure')
-      @pipelines = Pipeline.order(@sort_by).page(params[:page])
+      @pipelines = pipelines
       render :index
     end
   end
@@ -78,9 +77,12 @@ class PipelinesController < ApplicationController
     @pipeline = Pipeline.find(params[:id])
   end
 
-  def assign_sort_by
-    @sort_by = { updated_at: :desc }
-    @sort_by = { name: :asc } if params['sort_by'] == 'name'
+  def pipelines
+    Pipeline.search(params[:search]).order(sort_by).page(params[:page])
+  end
+
+  def sort_by
+    @sort_by ||= params['sort_by'] == 'name' ? { name: :asc } : { updated_at: :desc }
   end
 
   def pipeline_params

--- a/app/controllers/pipelines_controller.rb
+++ b/app/controllers/pipelines_controller.rb
@@ -79,8 +79,8 @@ class PipelinesController < ApplicationController
   end
 
   def assign_sort_by
-    @sort_by = { name: :asc }
-    @sort_by = { updated_at: :desc } if params['sort_by'] == 'updated_at'
+    @sort_by = { updated_at: :desc }
+    @sort_by = { name: :asc } if params['sort_by'] == 'name'
   end
 
   def pipeline_params

--- a/app/frontend/entrypoints/application.js
+++ b/app/frontend/entrypoints/application.js
@@ -37,7 +37,7 @@ import "/js/TestTransformationRecordSelector";
 import "/js/TestDestination";
 import "/js/Tooltips";
 import "/js/CollapseScroll";
-import "/js/PipelineSort";
+import "/js/SubmittingSelect";
 import "/js/CreateModal";
 import "/js/AutoComplete";
 

--- a/app/frontend/entrypoints/application.js
+++ b/app/frontend/entrypoints/application.js
@@ -37,7 +37,7 @@ import "/js/TestTransformationRecordSelector";
 import "/js/TestDestination";
 import "/js/Tooltips";
 import "/js/CollapseScroll";
-import "/js/ContentSourceFilter";
+import "/js/PipelineSort";
 import "/js/CreateModal";
 import "/js/AutoComplete";
 

--- a/app/frontend/entrypoints/application.js
+++ b/app/frontend/entrypoints/application.js
@@ -31,6 +31,7 @@ console.log(
 // import '~/index.css'
 
 import * as bootstrap from "bootstrap";
+import "/js/ClearField";
 import "/js/TestRecordExtraction";
 import "/js/TestEnrichmentExtraction";
 import "/js/TestTransformationRecordSelector";

--- a/app/frontend/entrypoints/application.scss
+++ b/app/frontend/entrypoints/application.scss
@@ -30,7 +30,7 @@
 
 
 // Blocks
-
+@import "../stylesheets/blocks/card-link";
 @import "../stylesheets/blocks/field-nav";
 @import "../stylesheets/blocks/field-nav-panel";
 @import "../stylesheets/blocks/form-in-dropdown";
@@ -39,5 +39,3 @@
 @import "../stylesheets/blocks/record-view";
 @import "../stylesheets/blocks/definition-group";
 @import "../stylesheets/blocks/table";
-
-@import "../stylesheets/base";

--- a/app/frontend/entrypoints/application.scss
+++ b/app/frontend/entrypoints/application.scss
@@ -26,12 +26,13 @@
 
 // Blocks
 @import "../stylesheets/blocks/card-link";
-@import "../stylesheets/blocks/search";
+@import "../stylesheets/blocks/definition-group";
 @import "../stylesheets/blocks/field-nav";
 @import "../stylesheets/blocks/field-nav-panel";
 @import "../stylesheets/blocks/form-in-dropdown";
+@import "../stylesheets/blocks/harvest-card";
 @import "../stylesheets/blocks/header";
 @import "../stylesheets/blocks/jump-to";
 @import "../stylesheets/blocks/record-view";
-@import "../stylesheets/blocks/definition-group";
+@import "../stylesheets/blocks/search";
 @import "../stylesheets/blocks/table";

--- a/app/frontend/entrypoints/application.scss
+++ b/app/frontend/entrypoints/application.scss
@@ -1,16 +1,13 @@
 // Modules
-
 @import "../stylesheets/modules/colors";
 @import "../stylesheets/modules/fonts";
 
 // Libraries
-
 @import "~bootstrap/scss/bootstrap";
 @import "~bootstrap-icons/font/bootstrap-icons.min";
 @import "~autoComplete/dist/css/autoComplete.css";
 
 // Mixins
-
 @import "../stylesheets/mixins/bem";
 
 // Bootstrap overrides
@@ -25,12 +22,11 @@
 @import "../stylesheets/bootstrap/accordion";
 
 // Library overrides
-
 @import "../stylesheets/autocomplete/autocomplete";
-
 
 // Blocks
 @import "../stylesheets/blocks/card-link";
+@import "../stylesheets/blocks/search";
 @import "../stylesheets/blocks/field-nav";
 @import "../stylesheets/blocks/field-nav-panel";
 @import "../stylesheets/blocks/form-in-dropdown";

--- a/app/frontend/js/ClearField.js
+++ b/app/frontend/js/ClearField.js
@@ -1,0 +1,14 @@
+const clearButtons = document.querySelectorAll("[data-clear-field]");
+
+clearButtons.forEach(function (clearButton) {
+  clearButton.addEventListener("click", (event) => {
+    const form = event.target.closest("form");
+    const fieldNameToClear = event.target.dataset.clearField;
+    const fieldToClear = form.querySelector(
+      `input[name="${fieldNameToClear}"]`
+    );
+
+    fieldToClear.value = "";
+    form.submit();
+  });
+});

--- a/app/frontend/js/ContentSourceFilter.js
+++ b/app/frontend/js/ContentSourceFilter.js
@@ -1,9 +1,0 @@
-const contentSourceFilter = document.getElementById("js-content-source-filter");
-
-if (contentSourceFilter) {
-  const form = contentSourceFilter.closest("form");
-
-  contentSourceFilter.addEventListener("change", (event) => {
-    form.submit();
-  });
-}

--- a/app/frontend/js/PipelineSort.js
+++ b/app/frontend/js/PipelineSort.js
@@ -1,9 +1,0 @@
-const selectElement = document.getElementById("js-pipeline-sort");
-
-if (selectElement) {
-  const form = selectElement.closest("form");
-
-  selectElement.addEventListener("change", () => {
-    form.submit();
-  });
-}

--- a/app/frontend/js/PipelineSort.js
+++ b/app/frontend/js/PipelineSort.js
@@ -1,0 +1,9 @@
+const selectElement = document.getElementById("js-pipeline-sort");
+
+if (selectElement) {
+  const form = selectElement.closest("form");
+
+  selectElement.addEventListener("change", () => {
+    form.submit();
+  });
+}

--- a/app/frontend/js/SubmittingSelect.js
+++ b/app/frontend/js/SubmittingSelect.js
@@ -1,0 +1,11 @@
+const selectElements = document.querySelectorAll(
+  '[data-submitting-select="true"]'
+);
+
+selectElements.forEach(function (selectElement) {
+  const form = selectElement.closest("form");
+
+  selectElement.addEventListener("change", () => {
+    form.submit();
+  });
+});

--- a/app/frontend/js/components/SharedDefinitionsView.jsx
+++ b/app/frontend/js/components/SharedDefinitionsView.jsx
@@ -16,7 +16,7 @@ const SharedDefinitionsView = ({ definitionType }) => {
           return (
             <div className="col-3" key={sharedDefinition.id}>
               <a
-                className="card mb-3"
+                className="card card--clickable mb-3"
                 href={`/pipelines/${sharedDefinition.pipeline.id}`}
               >
                 <div className="card-body">

--- a/app/frontend/stylesheets/_base.scss
+++ b/app/frontend/stylesheets/_base.scss
@@ -1,5 +1,0 @@
-body {
-  background-color: $bleached-silk;
-  color: $antarctic-deep;
-  font-family: 'Lato', sans-serif;
-}

--- a/app/frontend/stylesheets/blocks/_card-link.scss
+++ b/app/frontend/stylesheets/blocks/_card-link.scss
@@ -6,12 +6,17 @@
     border-color: $primary;
   }
 
-  .card__link::after {
-    content: "";
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
+  .card__link {
+    color: var(--bs-card-color);
+    text-decoration: none;
+
+    &::after {
+      content: "";
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      left: 0;
+      right: 0;
+    }
   }
 }

--- a/app/frontend/stylesheets/blocks/_card-link.scss
+++ b/app/frontend/stylesheets/blocks/_card-link.scss
@@ -1,0 +1,17 @@
+// this is used to make a card which has interactive elements
+// clickable without breaking a11y
+// See https://inclusive-components.design/cards/
+.card--clickable {
+  &:hover {
+    border-color: $primary;
+  }
+
+  .card__link::after {
+    content: "";
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+  }
+}

--- a/app/frontend/stylesheets/blocks/_harvest-card.scss
+++ b/app/frontend/stylesheets/blocks/_harvest-card.scss
@@ -1,18 +1,22 @@
 .harvest-card {
-  @include element('control') {
+  @include element('actions') {
     position: absolute;
-    right: .5rem;
+    right: 0rem;
     top: 0;
     bottom: 0;
     margin: auto;
-    height: 1rem;
+    height: 2.25rem;
 
     &:hover {
       cursor: pointer;
     }
   }
 
-  @include element('control-action') {
+  @include element('actions-toggle') {
+    border: none;
+  }
+
+  @include element('action') {
     padding: .625rem 1rem;
   }
 

--- a/app/frontend/stylesheets/blocks/_harvest-card.scss
+++ b/app/frontend/stylesheets/blocks/_harvest-card.scss
@@ -1,0 +1,29 @@
+.harvest-card {
+  @include element('control') {
+    position: absolute;
+    right: .5rem;
+    top: 0;
+    bottom: 0;
+    margin: auto;
+    height: 1rem;
+
+    &:hover {
+      cursor: pointer;
+    }
+  }
+
+  @include element('control-action') {
+    padding: .625rem 1rem;
+  }
+
+  @include element('right-arrow') {
+    position: absolute;
+    right: -1.5rem;
+    top: 0;
+    bottom: 0;
+    width: 1.25rem;
+    height: 1.25rem;
+    margin: auto;
+    color: $primary;
+  }
+}

--- a/app/frontend/stylesheets/blocks/_search.scss
+++ b/app/frontend/stylesheets/blocks/_search.scss
@@ -1,0 +1,51 @@
+.search {
+  position: relative;
+
+  @include element('label') {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    padding: .4rem $form-floating-padding-x;
+    overflow: hidden;
+    text-align: start;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    pointer-events: none;
+    border: 1px solid transparent;
+  }
+
+  &__input {
+    width: 22rem;
+
+    &::placeholder {
+      color: transparent;
+    }
+
+    &:focus ~ .search__label, &:not(:placeholder-shown) ~ .search__label {
+      display: none;
+    }
+  }
+
+  @include element('clear') {
+    position: absolute;
+    top: 0;
+    right: .5rem;
+    margin-top: .3rem;
+
+    --bs-btn-padding-y: .25rem;
+    --bs-btn-padding-x: .5rem;
+    --bs-btn-font-size: .75rem;
+    --bs-btn-border-color: #{$lynx-white};
+    --bs-btn-bg: #{$lynx-white};
+    --bs-btn-color: #{$primary};
+    --bs-btn-hover-color: #{$primary};
+    --bs-btn-hover-bg: #{shade-color($lynx-white, 10%)};
+    --bs-btn-hover-border-color: #{shade-color($lynx-white, 10%)};
+
+    > .bi-plus::before {
+      transform: rotate(45deg);
+    }
+  }
+}

--- a/app/frontend/stylesheets/bootstrap/_card.scss
+++ b/app/frontend/stylesheets/bootstrap/_card.scss
@@ -34,7 +34,7 @@
   }
 
   @include element('control-action') {
-    padding: 10px 16px 9px 16px;
+    padding: .625rem 1rem;
   }
 
   @include element('control') {

--- a/app/frontend/stylesheets/bootstrap/_card.scss
+++ b/app/frontend/stylesheets/bootstrap/_card.scss
@@ -62,12 +62,6 @@
   }
 }
 
-a.card {
-  &:hover {
-    border-color: $primary;
-  }
-}
-
 form {
   .card {
     background: $doctor;

--- a/app/frontend/stylesheets/bootstrap/_card.scss
+++ b/app/frontend/stylesheets/bootstrap/_card.scss
@@ -32,34 +32,6 @@
       cursor: default
     }
   }
-
-  @include element('control-action') {
-    padding: .625rem 1rem;
-  }
-
-  @include element('control') {
-    position: absolute;
-    right: .5rem;
-    top: 0;
-    bottom: 0;
-    margin: auto;
-    height: 1rem;
-
-    &:hover {
-      cursor: pointer;
-    }
-  }
-
-  @include element('right-arrow') {
-      position: absolute;
-      right: -1.5rem;
-      top: 0;
-      bottom: 0;
-      width: 1.25rem;
-      height: 1.25rem;
-      margin: auto;
-      color: $primary;
-  }
 }
 
 form {

--- a/app/frontend/stylesheets/bootstrap/_form.scss
+++ b/app/frontend/stylesheets/bootstrap/_form.scss
@@ -1,3 +1,3 @@
-.form-label {
+.form-label, .col-form-label {
   font-weight: 600;
 }

--- a/app/frontend/stylesheets/modules/_colors.scss
+++ b/app/frontend/stylesheets/modules/_colors.scss
@@ -1,12 +1,13 @@
-// https://color-name-generator.com/ 
+// https://color-name-generator.com/
 
 $doctor: #F8F9FA;
 $bleached-silk: #F2F2F2;
 $vital-green: #198754;
 $antarctic-deep: #343A40;
-$bright-star: #dee2e6;
-$pompeii-ash: #6c757d;
-$satin-white: #ced4da;
+$bright-star: #DEE2E6;
+$pompeii-ash: #6C757D;
+$satin-white: #CED4DA;
+$lynx-white: #F7F7F7;
 
 $primary: $vital-green;
 $dark: $antarctic-deep;

--- a/app/models/extraction_definition.rb
+++ b/app/models/extraction_definition.rb
@@ -3,6 +3,8 @@
 # Used to store the information for running an extraction
 #
 class ExtractionDefinition < ApplicationRecord
+  FORMATS = %w[JSON XML HTML].freeze
+
   # The destination is used for Enrichment Extractions
   # To know where to pull the records that are to be enriched from
   belongs_to :destination, optional: true
@@ -39,7 +41,7 @@ class ExtractionDefinition < ApplicationRecord
 
   # Harvest related validation
   with_options if: :harvest? do
-    validates :format, presence: true, inclusion: { in: %w[JSON XML HTML] }
+    validates :format, presence: true, inclusion: { in: FORMATS }
     validates :base_url, presence: true, format: { with: URI::DEFAULT_PARSER.make_regexp }
     validate :total_selector_format
     validates :total_selector, presence: true

--- a/app/models/pipeline.rb
+++ b/app/models/pipeline.rb
@@ -13,7 +13,7 @@ class Pipeline < ApplicationRecord
   validates :name, presence: true, uniqueness: true
 
   def self.search(words)
-    words = sanitize_sql_like(words)
+    words = sanitize_sql_like(words || '')
     return self if words.empty?
 
     where('name LIKE ?', "%#{words}%").or(where('description LIKE ?', "%#{words}%"))

--- a/app/models/pipeline.rb
+++ b/app/models/pipeline.rb
@@ -12,7 +12,7 @@ class Pipeline < ApplicationRecord
 
   validates :name, presence: true, uniqueness: true
 
-  def self.search(words)
+  def self.search(words, _format)
     words = sanitize_sql_like(words || '')
     return self if words.empty?
 

--- a/app/models/pipeline.rb
+++ b/app/models/pipeline.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Pipeline < ApplicationRecord
+  paginates_per 20
+
   has_many :harvest_definitions, dependent: :destroy
   has_many :harvest_jobs, through: :harvest_definitions
   belongs_to :last_edited_by, class_name: 'User', optional: true

--- a/app/models/pipeline.rb
+++ b/app/models/pipeline.rb
@@ -16,7 +16,12 @@ class Pipeline < ApplicationRecord
     words = sanitize_sql_like(words || '')
     return self if words.empty?
 
-    where('name LIKE ?', "%#{words}%").or(where('description LIKE ?', "%#{words}%"))
+    words = "%#{words}%"
+    users = User.select(:id).where('username LIKE ?', words)
+
+    where('name LIKE ?', words)
+      .or(where('description LIKE ?', words))
+      .or(where(last_edited_by: users))
   end
 
   def harvest

--- a/app/models/pipeline.rb
+++ b/app/models/pipeline.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Pipeline < ApplicationRecord
-  paginates_per 20
+  paginates_per 19 # not 20 because of the "Create new pipeline" button
 
   has_many :harvest_definitions, dependent: :destroy
   has_many :harvest_jobs, through: :harvest_definitions

--- a/app/models/pipeline.rb
+++ b/app/models/pipeline.rb
@@ -25,25 +25,6 @@ class Pipeline < ApplicationRecord
     query
   end
 
-  def self.sanitized_words(words)
-    words = sanitize_sql_like(words || '')
-    return nil if words.empty?
-
-    "%#{words}%"
-  end
-
-  def self.search_user_ids(words)
-    User.where('username LIKE ?', words).pluck(:id)
-  end
-
-  def self.search_source_ids(words)
-    HarvestDefinition.where('source_id LIKE ?', words).pluck(:pipeline_id)
-  end
-
-  def self.search_format_ids(format)
-    ExtractionDefinition.where(format:).pluck(:pipeline_id)
-  end
-
   def harvest
     harvest_definitions.find_by(kind: 'harvest')
   end

--- a/app/models/pipeline.rb
+++ b/app/models/pipeline.rb
@@ -12,6 +12,13 @@ class Pipeline < ApplicationRecord
 
   validates :name, presence: true, uniqueness: true
 
+  def self.search(words)
+    words = sanitize_sql_like(words)
+    return self if words.empty?
+
+    where('name LIKE ?', "%#{words}%").or(where('description LIKE ?', "%#{words}%"))
+  end
+
   def harvest
     harvest_definitions.find_by(kind: 'harvest')
   end

--- a/app/queries/pipeline_search_query.rb
+++ b/app/queries/pipeline_search_query.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+class PipelineSearchQuery
+  def initialize(params)
+    @words = sanitized_words(params[:search])
+    @format = params[:format]
+    @query = Pipeline
+  end
+
+  def call
+    return @query if @words.blank? && @format.blank?
+    return @query.where(id: search_format_ids) if @words.blank? && @format.present?
+
+    @query = or_words_filters
+    @query = and_format_filter if @format.present?
+
+    @query
+  end
+
+  private
+
+  def sanitized_words(words)
+    words = Pipeline.sanitize_sql_like(words || '')
+    return nil if words.empty?
+
+    "%#{words}%"
+  end
+
+  def or_words_filters
+    @query.where('name LIKE ?', @words)
+          .or(Pipeline.where('description LIKE ?', @words))
+          .or(Pipeline.where(last_edited_by_id: search_user_ids))
+          .or(Pipeline.where(id: search_source_ids))
+  end
+
+  def and_format_filter
+    @query.and(Pipeline.where(id: search_format_ids))
+  end
+
+  def search_user_ids
+    User.where('username LIKE ?', @words).pluck(:id)
+  end
+
+  def search_source_ids
+    HarvestDefinition.where('source_id LIKE ?', @words).pluck(:pipeline_id)
+  end
+
+  def search_format_ids
+    ExtractionDefinition.where(format: @format).pluck(:pipeline_id)
+  end
+end

--- a/app/views/destinations/index.html.erb
+++ b/app/views/destinations/index.html.erb
@@ -18,9 +18,9 @@
   <div class='row'>
     <%- @destinations.each do |destination| %>
       <div class='col-3'>
-        <%= link_to destination, class: 'card mb-3' do %>
+        <%= link_to destination, class: 'card card--clickable mb-3' do %>
           <div class='card-body'>
-              <h5 class='card-title'><%= destination.name %></h5>
+            <h5 class='card-title'><%= destination.name %></h5>
           </div>
         <% end %>
       </div>

--- a/app/views/jobs/_jobs.html.erb
+++ b/app/views/jobs/_jobs.html.erb
@@ -5,7 +5,7 @@
         <%= link_to pipeline_harvest_definition_extraction_definition_extraction_job_path(
               pipeline, harvest_definition, extraction_definition, job
             ),
-                    class: 'card mb-3' do %>
+                    class: 'card card--clickable mb-3' do %>
           <div class='card-body'>
             <h5 class='card-title'><%= job.name %></h5>
             <h6 class='card-subtitle'><%= job.updated_at.to_fs(:light) %></h6>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title><%= content_for?(:title) ? "#{yield(:title)} | " : '' %>Harvester</title>
     <meta name="viewport" content="width=device-width,initial-scale=1">

--- a/app/views/pipelines/_card.html.erb
+++ b/app/views/pipelines/_card.html.erb
@@ -7,14 +7,14 @@
 
 <div class="card card--clickable">
   <div class='card-body'>
-    <h5 class="card-title">
+    <h2 class="card-title">
       <%= link_to edit_path, class: 'card__link' do %>
         <%= definition.name %>
       <% end %>
-    </h5>
-    <h6 class="card-subtitle">
+    </h2>
+    <h3 class="card-subtitle">
       <%= send("#{type}_card_subtitle", definition) %>
-    </h6>
+    </h3>
 
     <% if definition.shared? %>
       <span class="badge text-bg-light">Shared (<%= "#{definition.harvest_definitions.count} pipelines" %>)</span>

--- a/app/views/pipelines/_card.html.erb
+++ b/app/views/pipelines/_card.html.erb
@@ -5,9 +5,13 @@
    delete_path ||= ''
    position = type == 'extraction' ? 'first' : 'last' %>
 
-<div class="card">
+<div class="card card--clickable">
   <div class='card-body'>
-    <h5 class="card-title"><%= definition.name %></h5>
+    <h5 class="card-title">
+      <%= link_to edit_path, class: 'card__link' do %>
+        <%= definition.name %>
+      <% end %>
+    </h5>
     <h6 class="card-subtitle">
       <%= send("#{type}_card_subtitle", definition) %>
     </h6>

--- a/app/views/pipelines/_card.html.erb
+++ b/app/views/pipelines/_card.html.erb
@@ -5,7 +5,7 @@
    delete_path ||= ''
    position = type == 'extraction' ? 'first' : 'last' %>
 
-<div class="card card--clickable">
+<div class="card harvest-card card--clickable">
   <div class='card-body'>
     <h2 class="card-title">
       <%= link_to edit_path, class: 'card__link' do %>
@@ -20,11 +20,11 @@
       <span class="badge text-bg-light">Shared (<%= "#{definition.harvest_definitions.count} pipelines" %>)</span>
     <% end %>
 
-    <div class="btn-group card__control">
+    <div class="btn-group harvest-card__control">
       <i class="bi bi-three-dots-vertical" data-bs-toggle='dropdown'></i>
       <ul class="dropdown-menu dropdown-menu-end">
         <li>
-          <%= link_to edit_path, class: 'dropdown-item card__control-action' do %>
+          <%= link_to edit_path, class: 'dropdown-item harvest-card__control-action' do %>
             <i class="bi bi-link-45deg me-2"></i><%= edit_text %>
           <% end %>
         </li>
@@ -32,7 +32,7 @@
         <% if definition.shared? %>
           <li>
             <a
-              class="dropdown-item card__control-action"
+              class="dropdown-item harvest-card__control-action"
               href="#"
               data-bs-toggle='modal'
               data-bs-target="<%= "#clone-definition-#{type}-#{definition.id}" %>">
@@ -42,7 +42,7 @@
 
           <li>
             <a
-              class="dropdown-item card__control-action"
+              class="dropdown-item harvest-card__control-action"
               href="#"
               data-bs-toggle='modal'
               data-bs-target="<%= "#remove-shared-#{type}-definition-#{definition.id}" %>">
@@ -52,7 +52,7 @@
         <% else %>
           <li>
             <a
-              class="dropdown-item card__control-action"
+              class="dropdown-item harvest-card__control-action"
               href="#"
               data-bs-toggle='modal'
               data-bs-target="<%= "#delete-#{type}-definition-#{definition.id}" %>">
@@ -63,7 +63,7 @@
 
         <% if jobs_path.present? %>
           <li>
-            <%= link_to jobs_path, class: 'dropdown-item card__control-action' do %>
+            <%= link_to jobs_path, class: 'dropdown-item harvest-card__control-action' do %>
               <i class="bi bi-eye me-2"></i> View Extraction Jobs
             <% end %>
           </li>
@@ -71,7 +71,7 @@
 
         <% if run_sample_extraction_path.present? %>
           <li>
-            <%= button_to run_sample_extraction_path, class: 'dropdown-item card__control-action' do %>
+            <%= button_to run_sample_extraction_path, class: 'dropdown-item harvest-card__control-action' do %>
               <i class="bi bi-play me-2"></i> Run Sample Extraction
             <% end %>
           </li>
@@ -79,7 +79,7 @@
 
         <% if run_full_extraction_path.present? %>
           <li>
-            <%= button_to run_full_extraction_path, class: 'dropdown-item card__control-action' do %>
+            <%= button_to run_full_extraction_path, class: 'dropdown-item harvest-card__control-action' do %>
               <i class="bi bi-play me-2"></i> Run Full Extraction
             <% end %>
           </li>
@@ -89,7 +89,7 @@
   </div>
 
   <% if position == 'first' %>
-    <i class="bi bi-arrow-right card__right-arrow"></i>
+    <i class="bi bi-arrow-right harvest-card__right-arrow"></i>
   <% end %>
 </div>
 

--- a/app/views/pipelines/_card.html.erb
+++ b/app/views/pipelines/_card.html.erb
@@ -7,85 +7,92 @@
 
 <div class="card harvest-card card--clickable">
   <div class='card-body'>
-    <h2 class="card-title">
-      <%= link_to edit_path, class: 'card__link' do %>
-        <%= definition.name %>
-      <% end %>
-    </h2>
-    <h3 class="card-subtitle">
-      <%= send("#{type}_card_subtitle", definition) %>
-    </h3>
+    <div class="row">
 
-    <% if definition.shared? %>
-      <span class="badge text-bg-light">Shared (<%= "#{definition.harvest_definitions.count} pipelines" %>)</span>
-    <% end %>
-
-    <div class="btn-group harvest-card__control">
-      <i class="bi bi-three-dots-vertical" data-bs-toggle='dropdown'></i>
-      <ul class="dropdown-menu dropdown-menu-end">
-        <li>
-          <%= link_to edit_path, class: 'dropdown-item harvest-card__control-action' do %>
-            <i class="bi bi-link-45deg me-2"></i><%= edit_text %>
+      <div class="col-11">
+        <h2 class="card-title">
+          <%= link_to edit_path, class: 'card__link' do %>
+            <%= definition.name %>
           <% end %>
-        </li>
-
+        </h2>
+        <h3 class="card-subtitle">
+          <%= send("#{type}_card_subtitle", definition) %>
+        </h3>
         <% if definition.shared? %>
-          <li>
-            <a
-              class="dropdown-item harvest-card__control-action"
-              href="#"
-              data-bs-toggle='modal'
-              data-bs-target="<%= "#clone-definition-#{type}-#{definition.id}" %>">
-                <i class="bi bi-layers me-2"></i>Clone and edit new definition
-              </a>
-          </li>
-
-          <li>
-            <a
-              class="dropdown-item harvest-card__control-action"
-              href="#"
-              data-bs-toggle='modal'
-              data-bs-target="<%= "#remove-shared-#{type}-definition-#{definition.id}" %>">
-                <i class="bi bi-trash me-2"></i>Remove shared definition
-              </a>
-          </li>
-        <% else %>
-          <li>
-            <a
-              class="dropdown-item harvest-card__control-action"
-              href="#"
-              data-bs-toggle='modal'
-              data-bs-target="<%= "#delete-#{type}-definition-#{definition.id}" %>">
-                <i class="bi bi-trash me-2"></i>Delete definition
-              </a>
-          </li>
+          <span class="badge text-bg-light">Shared (<%= "#{definition.harvest_definitions.count} pipelines" %>)</span>
         <% end %>
+      </div>
 
-        <% if jobs_path.present? %>
-          <li>
-            <%= link_to jobs_path, class: 'dropdown-item harvest-card__control-action' do %>
-              <i class="bi bi-eye me-2"></i> View Extraction Jobs
+      <div class="col-1">
+        <div class="btn-group harvest-card__control">
+          <i class="bi bi-three-dots-vertical" data-bs-toggle='dropdown'></i>
+          <ul class="dropdown-menu dropdown-menu-end">
+            <li>
+              <%= link_to edit_path, class: 'dropdown-item harvest-card__control-action' do %>
+                <i class="bi bi-link-45deg me-2"></i><%= edit_text %>
+              <% end %>
+            </li>
+
+            <% if definition.shared? %>
+              <li>
+                <a
+                  class="dropdown-item harvest-card__control-action"
+                  href="#"
+                  data-bs-toggle='modal'
+                  data-bs-target="<%= "#clone-definition-#{type}-#{definition.id}" %>">
+                    <i class="bi bi-layers me-2"></i>Clone and edit new definition
+                  </a>
+              </li>
+
+              <li>
+                <a
+                  class="dropdown-item harvest-card__control-action"
+                  href="#"
+                  data-bs-toggle='modal'
+                  data-bs-target="<%= "#remove-shared-#{type}-definition-#{definition.id}" %>">
+                    <i class="bi bi-trash me-2"></i>Remove shared definition
+                  </a>
+              </li>
+            <% else %>
+              <li>
+                <a
+                  class="dropdown-item harvest-card__control-action"
+                  href="#"
+                  data-bs-toggle='modal'
+                  data-bs-target="<%= "#delete-#{type}-definition-#{definition.id}" %>">
+                    <i class="bi bi-trash me-2"></i>Delete definition
+                  </a>
+              </li>
             <% end %>
-          </li>
-        <% end %>
 
-        <% if run_sample_extraction_path.present? %>
-          <li>
-            <%= button_to run_sample_extraction_path, class: 'dropdown-item harvest-card__control-action' do %>
-              <i class="bi bi-play me-2"></i> Run Sample Extraction
+            <% if jobs_path.present? %>
+              <li>
+                <%= link_to jobs_path, class: 'dropdown-item harvest-card__control-action' do %>
+                  <i class="bi bi-eye me-2"></i> View Extraction Jobs
+                <% end %>
+              </li>
             <% end %>
-          </li>
-        <% end %>
 
-        <% if run_full_extraction_path.present? %>
-          <li>
-            <%= button_to run_full_extraction_path, class: 'dropdown-item harvest-card__control-action' do %>
-              <i class="bi bi-play me-2"></i> Run Full Extraction
+            <% if run_sample_extraction_path.present? %>
+              <li>
+                <%= button_to run_sample_extraction_path, class: 'dropdown-item harvest-card__control-action' do %>
+                  <i class="bi bi-play me-2"></i> Run Sample Extraction
+                <% end %>
+              </li>
             <% end %>
-          </li>
-        <% end %>
-      </ul>
+
+            <% if run_full_extraction_path.present? %>
+              <li>
+                <%= button_to run_full_extraction_path, class: 'dropdown-item harvest-card__control-action' do %>
+                  <i class="bi bi-play me-2"></i> Run Full Extraction
+                <% end %>
+              </li>
+            <% end %>
+          </ul>
+        </div>
+      </div>
     </div>
+
   </div>
 
   <% if position == 'first' %>

--- a/app/views/pipelines/_card.html.erb
+++ b/app/views/pipelines/_card.html.erb
@@ -24,11 +24,13 @@
       </div>
 
       <div class="col-1">
-        <div class="btn-group harvest-card__control">
-          <i class="bi bi-three-dots-vertical" data-bs-toggle='dropdown'></i>
+        <div class="dropdown harvest-card__actions">
+          <button class="btn btn-clear harvest-card__actions-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false" aria-label="Toggle actions dropdown">
+            <i class="bi bi-three-dots-vertical" aria-hidden="true"></i>
+          </button>
           <ul class="dropdown-menu dropdown-menu-end">
             <li>
-              <%= link_to edit_path, class: 'dropdown-item harvest-card__control-action' do %>
+              <%= link_to edit_path, class: 'dropdown-item harvest-card__action' do %>
                 <i class="bi bi-link-45deg me-2"></i><%= edit_text %>
               <% end %>
             </li>
@@ -36,7 +38,7 @@
             <% if definition.shared? %>
               <li>
                 <a
-                  class="dropdown-item harvest-card__control-action"
+                  class="dropdown-item harvest-card__action"
                   href="#"
                   data-bs-toggle='modal'
                   data-bs-target="<%= "#clone-definition-#{type}-#{definition.id}" %>">
@@ -46,7 +48,7 @@
 
               <li>
                 <a
-                  class="dropdown-item harvest-card__control-action"
+                  class="dropdown-item harvest-card__action"
                   href="#"
                   data-bs-toggle='modal'
                   data-bs-target="<%= "#remove-shared-#{type}-definition-#{definition.id}" %>">
@@ -56,7 +58,7 @@
             <% else %>
               <li>
                 <a
-                  class="dropdown-item harvest-card__control-action"
+                  class="dropdown-item harvest-card__action"
                   href="#"
                   data-bs-toggle='modal'
                   data-bs-target="<%= "#delete-#{type}-definition-#{definition.id}" %>">
@@ -67,7 +69,7 @@
 
             <% if jobs_path.present? %>
               <li>
-                <%= link_to jobs_path, class: 'dropdown-item harvest-card__control-action' do %>
+                <%= link_to jobs_path, class: 'dropdown-item harvest-card__action' do %>
                   <i class="bi bi-eye me-2"></i> View Extraction Jobs
                 <% end %>
               </li>
@@ -75,7 +77,7 @@
 
             <% if run_sample_extraction_path.present? %>
               <li>
-                <%= button_to run_sample_extraction_path, class: 'dropdown-item harvest-card__control-action' do %>
+                <%= button_to run_sample_extraction_path, class: 'dropdown-item harvest-card__action' do %>
                   <i class="bi bi-play me-2"></i> Run Sample Extraction
                 <% end %>
               </li>
@@ -83,7 +85,7 @@
 
             <% if run_full_extraction_path.present? %>
               <li>
-                <%= button_to run_full_extraction_path, class: 'dropdown-item harvest-card__control-action' do %>
+                <%= button_to run_full_extraction_path, class: 'dropdown-item harvest-card__action' do %>
                   <i class="bi bi-play me-2"></i> Run Full Extraction
                 <% end %>
               </li>

--- a/app/views/pipelines/index.html.erb
+++ b/app/views/pipelines/index.html.erb
@@ -17,7 +17,7 @@
           :sort_by,
           [['Last Edited', 'updated_at'], ['Alphabetical', 'name']],
           { selected: @sort_by.keys.first },
-          class: 'form-select', id: 'js-pipeline-sort'
+          class: 'form-select', 'data-submitting-select': true
         ) %>
   </div>
   <div class="col"></div>
@@ -37,7 +37,7 @@
   <div class='col-3'>
     <button type="button" class="card mb-3 card--create-cta d-flex" data-bs-toggle="modal" data-bs-target="#create-modal">
       <div class="card-body align-items-center d-flex justify-content-center">
-        <h5 class="card-title">+ Create new pipeline</h5>
+        <h2 class="card-title">+ Create new pipeline</h5>
       </div>
     </button>
   </div>
@@ -46,10 +46,10 @@
     <div class='col-3'>
       <%= link_to pipeline, class: 'card card--clickable mb-3 d-flex' do %>
         <div class="card-body">
-          <h5 class="card-title"><%= pipeline.name %></h5>
-          <h6 class="card-subtitle">
+          <h2 class="card-title"><%= pipeline.name %></h2>
+          <h3 class="card-subtitle">
             <%= last_edited_by(pipeline) %>
-          </h6>
+          </h3>
           <div>
             <span class="badge bg-light text-dark">
               <%= pipeline.harvest_definitions.harvest.count %> Harvest

--- a/app/views/pipelines/index.html.erb
+++ b/app/views/pipelines/index.html.erb
@@ -20,10 +20,11 @@
 
       <li class='list-inline-item'>
         <%= form_with url: '/pipelines', method: :get do |form| %>
-          <%= select_tag(
+          <%= form.select(
                 :sort_by,
-                options_for_select([['Alphabetical', 'name'], ['Last Edited', 'updated_at']], @sort_by.first),
-                class: 'form-select', id: 'js-content-source-filter'
+                [['Last Edited', 'updated_at'], ['Alphabetical', 'name']],
+                { selected: @sort_by.keys.first },
+                class: 'form-select', id: 'js-pipeline-sort'
               ) %>
         <% end %>
       </li>

--- a/app/views/pipelines/index.html.erb
+++ b/app/views/pipelines/index.html.erb
@@ -20,6 +20,16 @@
           class: 'form-select', id: 'js-pipeline-sort'
         ) %>
   </div>
+  <div class="col"></div>
+  <div class="col-auto">
+    <%= form.label :search, 'Search:', class: 'col-form-label' %>
+  </div>
+  <div class="col-auto">
+    <div class="input-group mb-3">
+      <%= form.text_field(:search, value: params[:search], class: 'form-control') %>
+      <button class="btn btn-primary" type="submit">Search</button>
+    </div>
+  </div>
 <% end %>
 
 <div class='row'>

--- a/app/views/pipelines/index.html.erb
+++ b/app/views/pipelines/index.html.erb
@@ -17,19 +17,17 @@
     </div>
   </div>
 
-  <!--
   <div class="col-auto pe-0">
     <%= form.label :format, 'Format:', class: 'col-form-label' %>
   </div>
   <div class="col-auto">
     <%= form.select(
           :format,
-          ExtractionDefinition::FORMATS,
-          { selected: @format },
+          [['All formats', '']] + ExtractionDefinition::FORMATS.map { |format| [format, format] },
+          { selected: params[:format].in?([nil, '', 'All formats']) ? 'All formats' : params[:format] },
           class: 'form-select', 'data-submitting-select': true
         ) %>
   </div>
-  -->
   <div class="col-auto pe-0">
     <%= form.label :sort_by, 'Sort by:', class: 'col-form-label' %>
   </div>

--- a/app/views/pipelines/index.html.erb
+++ b/app/views/pipelines/index.html.erb
@@ -9,7 +9,28 @@
 <% end %>
 
 <%= form_with url: '/pipelines', method: :get, class: 'row mb-4' do |form| %>
+  <div class="col"></div>
   <div class="col-auto">
+    <div class="input-group mb-3">
+      <%= form.text_field(:search, value: params[:search], class: 'form-control', 'aria-label': 'Search') %>
+      <button class="btn btn-primary" type="submit">Search</button>
+    </div>
+  </div>
+
+  <!--
+  <div class="col-auto pe-0">
+    <%= form.label :format, 'Format:', class: 'col-form-label' %>
+  </div>
+  <div class="col-auto">
+    <%= form.select(
+          :format,
+          ExtractionDefinition::FORMATS,
+          { selected: @format },
+          class: 'form-select', 'data-submitting-select': true
+        ) %>
+  </div>
+  -->
+  <div class="col-auto pe-0">
     <%= form.label :sort_by, 'Sort by:', class: 'col-form-label' %>
   </div>
   <div class="col-auto">
@@ -19,16 +40,6 @@
           { selected: @sort_by.keys.first },
           class: 'form-select', 'data-submitting-select': true
         ) %>
-  </div>
-  <div class="col"></div>
-  <div class="col-auto">
-    <%= form.label :search, 'Search:', class: 'col-form-label' %>
-  </div>
-  <div class="col-auto">
-    <div class="input-group mb-3">
-      <%= form.text_field(:search, value: params[:search], class: 'form-control') %>
-      <button class="btn btn-primary" type="submit">Search</button>
-    </div>
   </div>
 <% end %>
 

--- a/app/views/pipelines/index.html.erb
+++ b/app/views/pipelines/index.html.erb
@@ -6,74 +6,60 @@
   <h1 class="header__title">Pipelines</h1>
 
   <div class="clearfix"></div>
-
 <% end %>
 
-  <div class="float-end">
-    <ul class='list-inline'>
-
-      <li class='list-inline-item'>
-        <strong>
-          Sort by:
-        </strong>
-      </li>
-
-      <li class='list-inline-item'>
-        <%= form_with url: '/pipelines', method: :get do |form| %>
-          <%= form.select(
-                :sort_by,
-                [['Last Edited', 'updated_at'], ['Alphabetical', 'name']],
-                { selected: @sort_by.keys.first },
-                class: 'form-select', id: 'js-pipeline-sort'
-              ) %>
-        <% end %>
-      </li>
-
-    </ul>
+<%= form_with url: '/pipelines', method: :get, class: 'row mb-4' do |form| %>
+  <div class="col-auto">
+    <%= form.label :sort_by, 'Sort by:', class: 'col-form-label' %>
   </div>
+  <div class="col-auto">
+    <%= form.select(
+          :sort_by,
+          [['Last Edited', 'updated_at'], ['Alphabetical', 'name']],
+          { selected: @sort_by.keys.first },
+          class: 'form-select', id: 'js-pipeline-sort'
+        ) %>
+  </div>
+<% end %>
 
-  <div class='clearfix'></div>
+<div class='row'>
 
-  <div class='mb-4'></div>
-
-  <div class='row'>
-
-    <div class='col-3'>
-      <button type="button" class="card mb-3 card--create-cta d-flex" data-bs-toggle="modal" data-bs-target="#create-modal">
-        <div class="card-body align-items-center d-flex justify-content-center">
-          <h5 class="card-title">+ Create new pipeline</h5>
-        </div>
-      </button>
-    </div>
-
-    <%- @pipelines.each do |pipeline| %>
-      <div class='col-3'>
-        <%= link_to pipeline, class: 'card card--clickable mb-3 d-flex' do %>
-          <div class="card-body">
-            <h5 class="card-title"><%= pipeline.name %></h5>
-            <h6 class="card-subtitle">
-              <%= last_edited_by(pipeline) %>
-            </h6>
-            <div>
-              <span class="badge bg-light text-dark">
-                <%= pipeline.harvest_definitions.harvest.count %> Harvest
-              </span>
-              <span class="badge bg-light text-dark">
-                <%= pipeline.harvest_definitions.enrichment.count %> Enrichments
-              </span>
-
-              <% if pipeline.schedules.any? %>
-                <span class="badge bg-primary">
-                  Scheduled
-                </span>
-              <% end %>
-            </div>
-          </div>
-        <% end %>
+  <div class='col-3'>
+    <button type="button" class="card mb-3 card--create-cta d-flex" data-bs-toggle="modal" data-bs-target="#create-modal">
+      <div class="card-body align-items-center d-flex justify-content-center">
+        <h5 class="card-title">+ Create new pipeline</h5>
       </div>
-    <%- end %>
-
+    </button>
   </div>
+
+  <%- @pipelines.each do |pipeline| %>
+    <div class='col-3'>
+      <%= link_to pipeline, class: 'card card--clickable mb-3 d-flex' do %>
+        <div class="card-body">
+          <h5 class="card-title"><%= pipeline.name %></h5>
+          <h6 class="card-subtitle">
+            <%= last_edited_by(pipeline) %>
+          </h6>
+          <div>
+            <span class="badge bg-light text-dark">
+              <%= pipeline.harvest_definitions.harvest.count %> Harvest
+            </span>
+            <span class="badge bg-light text-dark">
+              <%= pipeline.harvest_definitions.enrichment.count %> Enrichments
+            </span>
+
+            <% if pipeline.schedules.any? %>
+              <span class="badge bg-primary">
+                Scheduled
+              </span>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  <%- end %>
+
+</div>
 
 <%= render 'shared/pagination_below_table', items: @pipelines %>
 

--- a/app/views/pipelines/index.html.erb
+++ b/app/views/pipelines/index.html.erb
@@ -48,7 +48,7 @@
 
     <%- @pipelines.each do |pipeline| %>
       <div class='col-3'>
-        <%= link_to pipeline, class: 'card mb-3 d-flex' do %>
+        <%= link_to pipeline, class: 'card card--clickable mb-3 d-flex' do %>
           <div class="card-body">
             <h5 class="card-title"><%= pipeline.name %></h5>
             <h6 class="card-subtitle">

--- a/app/views/pipelines/index.html.erb
+++ b/app/views/pipelines/index.html.erb
@@ -8,13 +8,30 @@
   <div class="clearfix"></div>
 <% end %>
 
-<%= form_with url: '/pipelines', method: :get, class: 'row mb-4' do |form| %>
-  <div class="col"></div>
-  <div class="col-auto">
-    <div class="input-group mb-3">
-      <%= form.text_field(:search, value: params[:search], class: 'form-control', 'aria-label': 'Search') %>
-      <button class="btn btn-primary" type="submit">Search</button>
+<%= form_with url: '/pipelines', method: :get, class: 'row justify-content-end mb-5' do |form| %>
+  <div class="col-auto pe-2">
+    <div class="search">
+      <%= form.text_field(
+            :search,
+            value: params[:search],
+            placeholder: 'Search by name, description, source_id, last edited by',
+            class: 'form-control search__input'
+          ) %>
+      <%= form.label :search, class: 'search__label' do %>
+        <i aria-hidden="true" class="bi bi-search"></i>
+        Search by name, description, source_id, last edited by
+      <% end %>
+
+      <% if params[:search].present? %>
+        <button type="button" class="btn btn-secondary search__clear" data-clear-field="search">
+          Clear
+          <i aria-hidden="true" class="bi bi-plus"></i>
+        </button>
+      <% end %>
     </div>
+  </div>
+  <div class="col-auto ps-0">
+    <button class="btn btn-primary" type="submit">Search</button>
   </div>
 
   <div class="col-auto pe-0">
@@ -28,6 +45,7 @@
           class: 'form-select', 'data-submitting-select': true
         ) %>
   </div>
+
   <div class="col-auto pe-0">
     <%= form.label :sort_by, 'Sort by:', class: 'col-form-label' %>
   </div>

--- a/app/views/schedules/index.html.erb
+++ b/app/views/schedules/index.html.erb
@@ -31,7 +31,7 @@
 <div class='row'>
 
   <div class='col-3'>
-    <%= link_to new_pipeline_schedule_path(@pipeline), class: 'card card--create-cta mb-3 d-flex' do %>
+    <%= link_to new_pipeline_schedule_path(@pipeline), class: 'card card--clickable card--create-cta mb-3 d-flex' do %>
       <div class='card-body align-items-center d-flex justify-content-center'>
         <h5 class="card-title">+ Create new schedule</h5>
       </div>
@@ -40,7 +40,7 @@
 
   <%- @schedules.each do |schedule| %>
     <div class='col-3'>
-      <%= link_to pipeline_schedule_path(@pipeline, schedule), class: 'card mb-3 d-flex' do %>
+      <%= link_to pipeline_schedule_path(@pipeline, schedule), class: 'card card--clickable mb-3 d-flex' do %>
         <div class="card-body">
           <h5 class="card-title"><%= schedule.name %></h5>
 

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -22,7 +22,7 @@
   <div class="row">
     <% @users.each do |user| %>
       <div class='col-3'>
-        <%= link_to user, class: 'card mb-3' do %>
+        <%= link_to user, class: 'card card--clickable mb-3' do %>
           <div class="card-body">
             <h5 class="card-title"><%= user.username %></h5>
             <p><%= user.email %></p>

--- a/config/application.rb
+++ b/config/application.rb
@@ -34,6 +34,7 @@ module Harvester
     # config.eager_load_paths << Rails.root.join("extras")
     config.eager_load_paths << Rails.root.join('supplejack')
     config.eager_load_paths << Rails.root.join('slices')
+    config.eager_load_paths << Rails.root.join('queries')
 
     config.time_zone = ENV.fetch('TIME_ZONE', 'Auckland')
 


### PR DESCRIPTION
[IMPROVE PIPELINE LIST PAGE: As Tim, I want to be able to search across Pipelines, so I can find examples and get where I need to go as easily as possible. ](https://www.pivotaltracker.com/story/show/186117863)

STORY
=====

**Acceptance Criteria**
- It is easy and quick to navigate through the growing list of Pipelines
- Clicking on a definition box takes you to the edit page
- Default sort order is recently modified first
- Equalize the cards height (bootstrap helper class)
- 20 cards per page

**Search**
- Search box searches across pipeline names and descriptions and source_id's?
- Can you search/filter by last edited name?

**Possibly save for later**
- Search/filter by format (xml, json, pagination, has an enrichment)?
- Search with in field code ?

**Notes**
- live load and/or autocomplete.js?



WHAT WAS DONE
==============

![image](https://github.com/DigitalNZ/supplejack_harvester/assets/4416830/150a9ac8-7518-46ee-b505-42a2c0a4d3ef)
