### PR TITLE
EXTRACTION STOP CONDITIONS: As Dan, I want a way to define when an extraction should stop so that the harvest does not run forever

### DIFF
--- a/app/models/extraction_definition.rb
+++ b/app/models/extraction_definition.rb
@@ -38,25 +38,16 @@ class ExtractionDefinition < ApplicationRecord
   validates :throttle, numericality: { only_integer: true, greater_than_or_equal_to: 0, less_than_or_equal_to: 60_000 }
 
   validates :page, numericality: { only_integer: true }
-  validates :per_page, numericality: { only_integer: true }
 
   # Harvest related validation
   with_options if: :harvest? do
     validates :format, presence: true, inclusion: { in: FORMATS }
     validates :base_url, presence: true, format: { with: URI::DEFAULT_PARSER.make_regexp }
-    validate :total_selector_format
-    validates :total_selector, presence: true
   end
 
   with_options presence: true, if: :enrichment? do
     validates :destination_id
     validates :source_id
-  end
-
-  def total_selector_format
-    return if FORMAT_SELECTOR_REGEX_MAP[format&.to_sym]&.match?(total_selector)
-
-    errors.add(:total_selector, "invalid selector for the #{format} format")
   end
 
   def to_h

--- a/app/supplejack/extraction/execution.rb
+++ b/app/supplejack/extraction/execution.rb
@@ -16,13 +16,13 @@ module Extraction
       return if @extraction_job.is_sample?
       return unless @extraction_definition.paginated?
 
-      # (@extraction_definition.page...max_pages).each do
       loop do
         @extraction_definition.page += 1
 
         extract_and_save_document(@extraction_definition.requests.last)
 
         throttle
+
         break if @extraction_job.reload.cancelled?
         break if stop_condition_met?
       end
@@ -31,7 +31,7 @@ module Extraction
     private
 
     def stop_condition_met?
-      set_number_reached?
+      [set_number_reached?, extraction_failed?, duplicate_document_extracted?].any?(true)
     end
 
     def set_number_reached?
@@ -39,7 +39,20 @@ module Extraction
 
       @harvest_job.pipeline_job.pages == @extraction_definition.page
     end
-    
+
+    def extraction_failed?
+      @de.document.status >= 400 || @de.document.status < 200
+    end
+
+    def duplicate_document_extracted?
+      previous_page = @extraction_definition.page - 1
+      previous_document = Extraction::Documents.new(@extraction_job.extraction_folder)[previous_page]
+
+      return false if previous_document.nil?
+
+      previous_document.body == @de.document.body
+    end
+
     def throttle
       sleep @extraction_definition.throttle / 1000.0
     end
@@ -47,6 +60,9 @@ module Extraction
     def extract_and_save_document(request)
       @de = DocumentExtraction.new(request, @extraction_job.extraction_folder, @previous_request)
       @previous_request = @de.extract
+
+      return if duplicate_document_extracted?
+
       @de.save
 
       if @harvest_report.present?
@@ -56,28 +72,6 @@ module Extraction
 
       enqueue_record_transformation
     end
-
-    # def max_pages
-      # return @harvest_job.pipeline_job.pages if @harvest_job.present? && @harvest_job.pipeline_job.set_number?
-
-      # (total_results / @extraction_definition.per_page) + 1
-    # end
-
-    # def total_results
-    #   send("#{@extraction_definition.format.downcase}_total_results_extractor")
-    # end
-
-    # def html_total_results_extractor
-    #   Nokogiri::HTML(@de.document.body).xpath(@extraction_definition.total_selector).first.content.to_i
-    # end
-
-    # def xml_total_results_extractor
-    #   Nokogiri::XML(@de.document.body).xpath(@extraction_definition.total_selector).first.content.to_i
-    # end
-
-    # def json_total_results_extractor
-    #   JsonPath.new(@extraction_definition.total_selector).on(@de.document.body).first.to_i
-    # end
 
     def enqueue_record_transformation
       return unless @harvest_job.present? && @de.document.successful?

--- a/app/supplejack/extraction/execution.rb
+++ b/app/supplejack/extraction/execution.rb
@@ -16,18 +16,30 @@ module Extraction
       return if @extraction_job.is_sample?
       return unless @extraction_definition.paginated?
 
-      (@extraction_definition.page...max_pages).each do
+      # (@extraction_definition.page...max_pages).each do
+      loop do
         @extraction_definition.page += 1
 
         extract_and_save_document(@extraction_definition.requests.last)
 
         throttle
         break if @extraction_job.reload.cancelled?
+        break if stop_condition_met?
       end
     end
 
     private
 
+    def stop_condition_met?
+      set_number_reached?
+    end
+
+    def set_number_reached?
+      return false unless @harvest_job.present? && @harvest_job.pipeline_job.set_number?
+
+      @harvest_job.pipeline_job.pages == @extraction_definition.page
+    end
+    
     def throttle
       sleep @extraction_definition.throttle / 1000.0
     end
@@ -45,27 +57,27 @@ module Extraction
       enqueue_record_transformation
     end
 
-    def max_pages
-      return @harvest_job.pipeline_job.pages if @harvest_job.present? && @harvest_job.pipeline_job.set_number?
+    # def max_pages
+      # return @harvest_job.pipeline_job.pages if @harvest_job.present? && @harvest_job.pipeline_job.set_number?
 
-      (total_results / @extraction_definition.per_page) + 1
-    end
+      # (total_results / @extraction_definition.per_page) + 1
+    # end
 
-    def total_results
-      send("#{@extraction_definition.format.downcase}_total_results_extractor")
-    end
+    # def total_results
+    #   send("#{@extraction_definition.format.downcase}_total_results_extractor")
+    # end
 
-    def html_total_results_extractor
-      Nokogiri::HTML(@de.document.body).xpath(@extraction_definition.total_selector).first.content.to_i
-    end
+    # def html_total_results_extractor
+    #   Nokogiri::HTML(@de.document.body).xpath(@extraction_definition.total_selector).first.content.to_i
+    # end
 
-    def xml_total_results_extractor
-      Nokogiri::XML(@de.document.body).xpath(@extraction_definition.total_selector).first.content.to_i
-    end
+    # def xml_total_results_extractor
+    #   Nokogiri::XML(@de.document.body).xpath(@extraction_definition.total_selector).first.content.to_i
+    # end
 
-    def json_total_results_extractor
-      JsonPath.new(@extraction_definition.total_selector).on(@de.document.body).first.to_i
-    end
+    # def json_total_results_extractor
+    #   JsonPath.new(@extraction_definition.total_selector).on(@de.document.body).first.to_i
+    # end
 
     def enqueue_record_transformation
       return unless @harvest_job.present? && @de.document.successful?

--- a/app/views/extraction_definitions/_create_edit_harvest_modal.html.erb
+++ b/app/views/extraction_definitions/_create_edit_harvest_modal.html.erb
@@ -83,20 +83,6 @@
             </div>
 
             <div class="col-4">
-              <%= form.label :total_selector, 'Total Selector', class: 'form-label' %>
-            </div>
-            <div class="col-8">
-              <%= form.text_field :total_selector, class: 'form-control', required: true %>
-            </div>
-
-            <div class="col-4">
-              <%= form.label :per_page, 'Per Page', class: 'form-label' %>
-            </div>
-            <div class="col-8">
-              <%= form.number_field :per_page, class: 'form-control', required: true %>
-            </div>
-
-            <div class="col-4">
               <%= form.label :paginated, class: 'form-label' do %>
                 Paginated
 

--- a/spec/factories/extraction_definition.rb
+++ b/spec/factories/extraction_definition.rb
@@ -7,8 +7,6 @@ FactoryBot.define do
     throttle { 0 }
     kind { 0 }
     per_page { 50 }
-    total_selector { '$.totalObjects' }
-    page { 1 }
     paginated { false }
 
     trait :figshare do
@@ -17,8 +15,6 @@ FactoryBot.define do
       base_url { 'https://api.figshare.com' }
       throttle { 1000 }
       page { 1 }
-      total_selector { '$.items_found' }
-      per_page { 10 }
       paginated { true }
     end
 

--- a/spec/models/extraction_definition_spec.rb
+++ b/spec/models/extraction_definition_spec.rb
@@ -47,7 +47,6 @@ RSpec.describe ExtractionDefinition do
     end
 
     it { is_expected.to validate_numericality_of(:page).only_integer }
-    it { is_expected.to validate_numericality_of(:per_page).only_integer }
   end
 
   describe '#validation' do

--- a/spec/models/extraction_job_spec.rb
+++ b/spec/models/extraction_job_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe ExtractionJob do
     let(:extraction_definition) { create(:extraction_definition, base_url: 'http://google.com', paginated: true) }
 
     before do
-      (1...6).each do |page|
+      (1...5).each do |page|
         request = create(:request, extraction_definition:)
         create(:parameter, name: 'url_param', content: 'url_value', kind: 'query', request:)
         create(:parameter, name: 'per_page', content: '50', kind: 'query', request:)
@@ -130,14 +130,14 @@ RSpec.describe ExtractionJob do
         stub_request(:get, 'http://google.com').with(
           query: { 'page' => page, 'per_page' => 50, 'url_param' => 'url_value' },
           headers: fake_json_headers
-        ).and_return(fake_response('test'))
+        ).and_return(fake_response("figshare_#{page}"))
       end
     end
 
     it 'returns the size of the extraction folder in bytes' do
       Extraction::Execution.new(subject, extraction_definition).call
 
-      expect(subject.extraction_folder_size_in_bytes).to eq 1535
+      expect(subject.extraction_folder_size_in_bytes).to eq 46334
     end
   end
 

--- a/spec/stub_responses/freesound_4.yaml
+++ b/spec/stub_responses/freesound_4.yaml
@@ -17,7 +17,7 @@ body: |-
   <root>
     <count>198</count>
     <previous>https://freesound.org/apiv2/search/text/?&query='Zealand'&weights=&page=3&page_size=50&fields=name,created,geotag,type,images,id,tags,license,username,url,description</previous>
-    <next/>
+    <next>https://freesound.org/apiv2/search/text/?&query='Zealand'&weights=&page=5&page_size=50&fields=name,created,geotag,type,images,id,tags,license,username,url,description</next>
     <results>
       <list-item>
         <id>417770</id>

--- a/spec/stub_responses/trove_5.yaml
+++ b/spec/stub_responses/trove_5.yaml
@@ -1,0 +1,25 @@
+---
+status: 200
+headers:
+  date: Wed, 21 Jun 2023 01:27:37 GMT
+  content-type: application/xml; charset=utf-8
+  content-length: 77854
+  connection: keep-alive
+  vary: Accept, Origin, Cookie
+  allow: GET, HEAD, OPTIONS
+  x-frame-options: DENY
+  x-content-type-options: nosniff
+  referrer-policy: same-origin, no-referrer-when-downgrade
+  x-mapped-host: freesound.org
+  strict-transport-security: max-age=31536000; preload
+body: |-
+    <?xml version="1.0" encoding="UTF-8"?>
+    <response>
+        <query>issn:0030-8722</query>
+        <zone name="article">
+            <records s="AoErc3UyMzQwNjcxOTQ=" n="100" total="300" next="/result?bulkHarvest=true&amp;encoding=xml&amp;include=tags%2Cworkversions&amp;l-australian=y&amp;l-availability=y&amp;n=100&amp;q=issn%3A0030-8722&amp;reclevel=full&amp;zone=article&amp;s=AoErc3UyMzQwNjcyOTU%3D" nextStart="AoErc3UyMzQwNjcyOTU=">
+            </records>
+        </zone>
+    </response>
+
+  

--- a/spec/supplejack/extraction/execution_spec.rb
+++ b/spec/supplejack/extraction/execution_spec.rb
@@ -199,18 +199,6 @@ RSpec.describe Extraction::Execution do
           before do
             stub_freesound_harvest_requests(request_one)
             stub_freesound_harvest_requests(request_two)
-
-            # TODO
-
-            stub_request(:get, "#{extraction_definition.base_url}?page=nokogiri-html-parse-response-at_xpath-html-body-root-next-content-match-page-page-page-evaluation-error&page_size=50").
-            with(
-              headers: {
-             'Accept'=>'*/*',
-             'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-             'Content-Type'=>'application/json',
-             'User-Agent'=>'Supplejack Harvester v2.0'
-              }).
-            to_return(fake_response('freesound_4'))
           end
 
           it 'enqueues 4 TransformationWorkers in sidekiq' do

--- a/spec/supplejack/extraction/execution_spec.rb
+++ b/spec/supplejack/extraction/execution_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Extraction::Execution do
         end_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
         total_time = end_time - start_time
 
-        expect(total_time.ceil).to eq 5
+        expect(total_time.ceil).to eq 6
       end
     end
 
@@ -138,6 +138,7 @@ RSpec.describe Extraction::Execution do
       context 'when the document has failed to be extracted' do
         before do
           stub_failed_figshare_harvest_requests(request_one)
+          stub_failed_figshare_harvest_requests(request_two)
         end
 
         let(:subject) { described_class.new(extraction_job, extraction_definition) }
@@ -154,8 +155,7 @@ RSpec.describe Extraction::Execution do
 
         context 'when the extraction_definition pagination_type is token' do
           let(:extraction_definition) do
-            create(:extraction_definition, format: 'JSON', total_selector: '$.total_results', page: 1, paginated: true,
-                                           per_page: 30)
+            create(:extraction_definition, format: 'JSON', page: 1, paginated: true)
           end
           let(:request_one) { create(:request, :inaturalist_initial_request, extraction_definition:) }
           let(:request_two) { create(:request, :inaturalist_main_request, extraction_definition:) }
@@ -174,7 +174,7 @@ RSpec.describe Extraction::Execution do
                                                 1 => '0',
                                                 2 => '2098031',
                                                 3 => '4218778',
-                                                4 => '7179629'
+                                                4 => '7179629',
                                               })
           end
 
@@ -191,8 +191,7 @@ RSpec.describe Extraction::Execution do
 
         context 'when the extraction_definition pagination_type is page' do
           let(:extraction_definition) do
-            create(:extraction_definition, format: 'XML', paginated: true, total_selector: '//count/text()',
-                                           page: 1, per_page: 50)
+            create(:extraction_definition, format: 'XML', paginated: true, page: 1)
           end
           let(:request_one) { create(:request, :freesound_initial_request, extraction_definition:) }
           let(:request_two) { create(:request, :freesound_main_request, extraction_definition:) }
@@ -200,6 +199,18 @@ RSpec.describe Extraction::Execution do
           before do
             stub_freesound_harvest_requests(request_one)
             stub_freesound_harvest_requests(request_two)
+
+            # TODO
+
+            stub_request(:get, "#{extraction_definition.base_url}?page=nokogiri-html-parse-response-at_xpath-html-body-root-next-content-match-page-page-page-evaluation-error&page_size=50").
+            with(
+              headers: {
+             'Accept'=>'*/*',
+             'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+             'Content-Type'=>'application/json',
+             'User-Agent'=>'Supplejack Harvester v2.0'
+              }).
+            to_return(fake_response('freesound_4'))
           end
 
           it 'enqueues 4 TransformationWorkers in sidekiq' do
@@ -211,8 +222,8 @@ RSpec.describe Extraction::Execution do
 
         context 'when the extraction_definition pagination_type is tokenised' do
           let(:extraction_definition) do
-            create(:extraction_definition, format: 'XML', pagination_type: 'tokenised', total_selector: '//records/@total',
-                                           page: 1, paginated: true, per_page: 100)
+            create(:extraction_definition, format: 'XML', pagination_type: 'tokenised',
+                                           page: 1, paginated: true)
           end
           let(:request_one)           { create(:request, :trove_initial_request, extraction_definition:) }
           let(:request_two)           { create(:request, :trove_main_request, extraction_definition:) }
@@ -223,11 +234,37 @@ RSpec.describe Extraction::Execution do
                                           1 => '*',
                                           2 => 'AoErc3UyMzQwNjY5OTI=',
                                           3 => 'AoErc3UyMzQwNjcwOTI=',
-                                          4 => 'AoErc3UyMzQwNjcxOTQ='
+                                          4 => 'AoErc3UyMzQwNjcxOTQ=',
+                                          5 => 'AoErc3UyMzQwNjcyOTU='
                                         })
           end
 
           it 'enqueues 4 TransformationWorkers in sidekiq' do
+            expect(TransformationWorker).to receive(:perform_async).exactly(4).times.and_call_original
+
+            subject.call
+          end
+        end
+
+        context 'when the same document is extracted multiple times' do
+          let(:extraction_definition) do
+            create(:extraction_definition, format: 'XML', pagination_type: 'tokenised', page: 1, paginated: true)
+          end
+          let(:request_one)           { create(:request, :trove_initial_request, extraction_definition:) }
+          let(:request_two)           { create(:request, :trove_main_request, extraction_definition:) }
+
+          before do
+            stub_trove_harvest_requests(request_one,
+                                        {
+                                          1 => '*',
+                                          2 => 'AoErc3UyMzQwNjY5OTI=',
+                                          3 => 'AoErc3UyMzQwNjcwOTI=',
+                                          4 => 'AoErc3UyMzQwNjcxOTQ=',
+                                          5 => 'AoErc3UyMzQwNjcyOTU='
+                                        })
+          end
+
+          it 'stops the harvest' do
             expect(TransformationWorker).to receive(:perform_async).exactly(4).times.and_call_original
 
             subject.call

--- a/spec/support/stub_harvest.rb
+++ b/spec/support/stub_harvest.rb
@@ -43,6 +43,7 @@ def stub_freesound_harvest_requests(request)
     ).to_return(fake_response("freesound_#{page}"))
   end
 
+  # Stub the last page with a duplicate so that the harvest finishes
   stub_request(:get, request.url).with(
     query: { 'page' => 5, 'page_size' => '50' }
   ).to_return(fake_response('freesound_4'))

--- a/spec/support/stub_harvest.rb
+++ b/spec/support/stub_harvest.rb
@@ -11,6 +11,16 @@ def stub_figshare_harvest_requests(request)
       headers: fake_json_headers
     ).to_return(fake_response("figshare_#{page}"))
   end
+
+  # Stub the last page as a duplicate so the harvest finishes
+  stub_request(:get, request.url).with(
+    query: {
+      'page' => 6,
+      'itemsPerPage' => 10,
+      'search_for' => 'zealand'
+    },
+    headers: fake_json_headers
+  ).to_return(fake_response('figshare_5'))
 end
 
 def stub_failed_figshare_harvest_requests(request)
@@ -18,7 +28,7 @@ def stub_failed_figshare_harvest_requests(request)
     stub_request(:get, request.url).with(
       query: {
         'page' => page,
-        'itemsPerPage' => request.extraction_definition.per_page,
+        'itemsPerPage' => request.parameters.find { |parameter| parameter.name == 'itemsPerPage' }.content,
         'search_for' => 'zealand'
       },
       headers: fake_json_headers
@@ -32,6 +42,10 @@ def stub_freesound_harvest_requests(request)
       query: { 'page' => page, 'page_size' => '50' }
     ).to_return(fake_response("freesound_#{page}"))
   end
+
+  stub_request(:get, request.url).with(
+    query: { 'page' => 5, 'page_size' => '50' }
+  ).to_return(fake_response('freesound_4'))
 end
 
 def stub_trove_harvest_requests(request, pages_and_tokens)
@@ -56,4 +70,13 @@ def stub_inaturalist_harvest_requests(extraction_definition, pages_and_tokens)
       headers: fake_json_headers
     ).to_return(fake_response("inaturalist_#{page}"))
   end
+
+  # Stub the last page as a duplicate so the harvest finishes
+  stub_request(:get, extraction_definition.base_url).with(
+    query: {
+      'per_page' => 30,
+      'id_above' => '11267278'
+    },
+    headers: fake_json_headers
+  ).to_return(fake_response('inaturalist_4'))
 end

--- a/spec/support/stub_harvest.rb
+++ b/spec/support/stub_harvest.rb
@@ -3,24 +3,15 @@
 def stub_figshare_harvest_requests(request)
   (1..5).each do |page|
     stub_request(:get, request.url).with(
-      query: {
-        'page' => page,
-        'itemsPerPage' => 10,
-        'search_for' => 'zealand'
-      },
+      query: { 'page' => page, 'itemsPerPage' => 10, 'search_for' => 'zealand' },
       headers: fake_json_headers
     ).to_return(fake_response("figshare_#{page}"))
   end
 
   # Stub the last page as a duplicate so the harvest finishes
-  stub_request(:get, request.url).with(
-    query: {
-      'page' => 6,
-      'itemsPerPage' => 10,
-      'search_for' => 'zealand'
-    },
-    headers: fake_json_headers
-  ).to_return(fake_response('figshare_5'))
+  stub_request(:get, request.url).with(query: { 'page' => 6, 'itemsPerPage' => 10, 'search_for' => 'zealand' },
+                                       headers: fake_json_headers)
+                                 .to_return(fake_response('figshare_5'))
 end
 
 def stub_failed_figshare_harvest_requests(request)
@@ -64,20 +55,13 @@ end
 def stub_inaturalist_harvest_requests(extraction_definition, pages_and_tokens)
   pages_and_tokens.each do |page, token|
     stub_request(:get, extraction_definition.base_url).with(
-      query: {
-        'per_page' => 30,
-        'id_above' => token
-      },
+      query: { 'per_page' => 30, 'id_above' => token },
       headers: fake_json_headers
     ).to_return(fake_response("inaturalist_#{page}"))
   end
 
   # Stub the last page as a duplicate so the harvest finishes
-  stub_request(:get, extraction_definition.base_url).with(
-    query: {
-      'per_page' => 30,
-      'id_above' => '11267278'
-    },
-    headers: fake_json_headers
-  ).to_return(fake_response('inaturalist_4'))
+  stub_request(:get, extraction_definition.base_url).with(query: { 'per_page' => 30, 'id_above' => '11267278' },
+                                                          headers: fake_json_headers)
+                                                    .to_return(fake_response('inaturalist_4'))
 end


### PR DESCRIPTION
**Acceptance Criteria**
- An extraction stops when the request is not successful (status code > 299 after redirects)
- User can define stop conditions when building the extraction [** maybe postpone for now**]
- Total selector and per page are removed from extraction definition

**Notes**
- Check-in with harvesters about retrying the last unsuccessful request
- FigShare keeps trying to extract pages past the erroring 900 limit, presumably until it gets to the expected total count.
- OAI's can also give some interesting feedback that would be nice to stop gracefully on without an ERROR so that enrichments could still be kicked off
- Should it stop if the record_selector finds no records?

**How about just these 2 hardcoded conditions and we add more customisable conditions later as/if the need arises**
- it stops after 2 consecutive identical responses
- obvious status code (is that >299 ?)