### PR TITLE
HARVEST A BATCH OF RECORDS: As a harvester, I want the API to be able to receive a batch of records, so that the process of harvesting is faster.

### DIFF
--- a/app/models/pipeline_job.rb
+++ b/app/models/pipeline_job.rb
@@ -51,6 +51,8 @@ class PipelineJob < ApplicationRecord
   end
 
   def harvest_completed?
+    return true if harvest_reports.find_by(kind: 'harvest').nil?
+
     harvest_reports.find_by(kind: 'harvest').completed?
   end
 

--- a/app/sidekiq/load_worker.rb
+++ b/app/sidekiq/load_worker.rb
@@ -13,9 +13,9 @@ class LoadWorker
 
     transformed_records = JSON.parse(records)
 
-    transformed_records.each do |transformed_record|
-      Load::Execution.new(transformed_record, @harvest_job, api_record_id).call
-      @harvest_report.increment_records_loaded!
+    transformed_records.each_slice(100) do |batch|
+      Load::Execution.new(batch, @harvest_job, api_record_id).call
+      @harvest_report.increment_records_loaded!(transformed_records.count)
       @harvest_report.update(load_updated_time: Time.zone.now)
     end
 

--- a/app/sidekiq/load_worker.rb
+++ b/app/sidekiq/load_worker.rb
@@ -15,7 +15,7 @@ class LoadWorker
 
     transformed_records.each_slice(100) do |batch|
       Load::Execution.new(batch, @harvest_job, api_record_id).call
-      @harvest_report.increment_records_loaded!(transformed_records.count)
+      @harvest_report.increment_records_loaded!(batch.count)
       @harvest_report.update(load_updated_time: Time.zone.now)
     end
 

--- a/spec/supplejack/load/execution_spec.rb
+++ b/spec/supplejack/load/execution_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Load::Execution do
       before do
         stub_request(:post, 'http://www.localhost:3000/harvester/records')
           .with(
-            body: "{\"record\":{\"title\":[\"title\"],\"description\":[\"description\"],\"source_id\":\"test\",\"priority\":0,\"job_id\":\"#{harvest_job.name}\"}}",
+            body: "{\"records\":[{\"fields\":{\"title\":[\"title\"],\"description\":[\"description\"],\"source_id\":\"test\",\"priority\":0,\"job_id\":\"#{harvest_job.name}\"}}]}",
             headers: {
               'Accept' => '*/*',
               'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
@@ -39,7 +39,7 @@ RSpec.describe Load::Execution do
       let(:harvest_job)        { create(:harvest_job, harvest_definition:, pipeline_job:) }
 
       it 'sends the record to the API correctly' do
-        expect(described_class.new(record, harvest_job).call.status).to eq 200
+        expect(described_class.new([record], harvest_job).call.status).to eq 200
       end
     end
 
@@ -66,7 +66,7 @@ RSpec.describe Load::Execution do
       end
 
       it 'sends the record to the API correctly' do
-        expect(described_class.new(record, harvest_job, 'record_id').call.status).to eq 200
+        expect(described_class.new([record], harvest_job, 'record_id').call.status).to eq 200
       end
     end
   end

--- a/spec/supplejack/load/execution_spec.rb
+++ b/spec/supplejack/load/execution_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Load::Execution do
   describe '#call' do
     context 'when the harvest definition is for a harvest' do
       before do
-        stub_request(:post, 'http://www.localhost:3000/harvester/records')
+        stub_request(:post, 'http://www.localhost:3000/harvester/records/create_batch')
           .with(
             body: "{\"records\":[{\"fields\":{\"title\":[\"title\"],\"description\":[\"description\"],\"source_id\":\"test\",\"priority\":0,\"job_id\":\"#{harvest_job.name}\"}}]}",
             headers: {


### PR DESCRIPTION
**Acceptance Criteria**

- The API can receive a batch of records to be created. 
- The harvester is using this endpoint 
- Both need to still be working 
- Existing SJ still works

**Notes**
- There is a current bottleneck on sending the Transformed records to the API because the API can only accept 1 record at a time. 