### PR TITLE
SJ LOAD WORKERS FAILING: As Tim, I want SJ to gracefully deal with unexpected issues, so that harvesting is reliable even with the odd DNS issue 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,6 +47,9 @@ gem 'webmock'
 # used for schedules
 gem 'sidekiq-cron'
 
+# load related
+gem 'retriable'
+
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -309,6 +309,7 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
+    retriable (3.1.2)
     rexml (3.2.6)
     rotp (6.2.2)
     rqrcode (2.2.0)
@@ -454,6 +455,7 @@ DEPENDENCIES
   pry-byebug
   puma (~> 5.0)
   rails (~> 7.0.4)
+  retriable
   rqrcode
   rspec-rails
   rubocop


### PR DESCRIPTION
**Acceptance Criteria**
- Harvests are reliable with all jobs being processed correctly

**Risks**
- ?

**Notes**
- Job 238 https://harvester.digitalnz.org/pipelines/36/pipeline_jobs didnt quite finish properly with some batches of records seemingly dropping through the cracks. Because a load batch is now 100 its much more noticable when one fails. 
- Tim had previously noticed the numbers not quite adding up and records not quite making it to solr. This is probably the same issue.
- Richard noticed this DNS issue inthe job mentioned above `2023-12-11T02:17:55.371Z pid=1 tid=1fz5 WARN: Faraday::ConnectionFailed: Failed to open TCP connection to api.staging.svc.cluster.local:80 (getaddrinfo: Try again)`
- One possible solution is a graceful retry when certain issues are encountered