### PR TITLE
2 SJ Bugs

### DIFF
--- a/.github/workflows/code_quality_score.yml
+++ b/.github/workflows/code_quality_score.yml
@@ -1,0 +1,9 @@
+name: Code quality score
+
+on:
+  - pull_request
+
+jobs:
+  code_quality_score:
+    name: Code quality
+    uses: boost/code_quality_score/.github/workflows/calculate-code-quality-score.yml@main

--- a/.github/workflows/code_quality_score.yml
+++ b/.github/workflows/code_quality_score.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   code_quality_score:
     name: Code quality
-    uses: boost/code_quality_score/.github/workflows/calculate-code-quality-score.yml@main
+    uses: DigitalNZ/code_quality_score/.github/workflows/calculate-code-quality-score.yml@main


### PR DESCRIPTION
### Bug 1: Using a cancelled extraction

### Steps to reproduce
1. Update the settings to use the cancelled extraction job. 
2. Save the modal.

### Expected
You should be able to transform a cancelled extraction.

### Actual
the page does not load fully and gets stuck on 
`Waiting for extraction to run. Please wait a minute and refresh the page.`


----------------------------------------------------------------------------------

--------------------------------------------------------------

### Bug  2: Schedule edit autopopulate

### Steps to reproduce
1. Notice the "destination" before pressing "Edit" on a schedule

### Expected
The page should auto populate with the same "destination" from the previous screen

### Actual
It seems to default to staging (even though it was previously Prod)