### PR TITLE
2 SJ Bugs

### DIFF
--- a/.github/workflows/code_quality_score.yml
+++ b/.github/workflows/code_quality_score.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   code_quality_score:
     name: Code quality
-    uses: DigitalNZ/code_quality_score/.github/workflows/calculate-code-quality-score.yml@main
+    uses: digitalnz/code_quality_score/.github/workflows/calculate-code-quality-score.yml@main

--- a/.github/workflows/code_quality_score.yml
+++ b/.github/workflows/code_quality_score.yml
@@ -1,0 +1,9 @@
+name: Code quality score
+
+on:
+  - pull_request
+
+jobs:
+  code_quality_score:
+    name: Code quality
+    uses: boost/code_quality_score/.github/workflows/calculate-code-quality-score.yml@main

--- a/.github/workflows/code_quality_score.yml
+++ b/.github/workflows/code_quality_score.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   code_quality_score:
     name: Code quality
-    uses: digitalnz/code_quality_score/.github/workflows/calculate-code-quality-score.yml@main
+    uses: DigitalNZ/code_quality_score/.github/workflows/calculate-code-quality-score.yml@main

--- a/.github/workflows/code_quality_score.yml
+++ b/.github/workflows/code_quality_score.yml
@@ -6,4 +6,4 @@ on:
 jobs:
   code_quality_score:
     name: Code quality
-    uses: boost/code_quality_score/.github/workflows/calculate-code-quality-score.yml@main
+    uses: DigitalNZ/code_quality_score/.github/workflows/calculate-code-quality-score.yml@main

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -238,7 +238,7 @@ GEM
     net-smtp (0.3.3)
       net-protocol
     netrc (0.11.0)
-    nio4r (2.5.9)
+    nio4r (2.7.0)
     nokogiri (1.15.4-aarch64-linux)
       racc (~> 1.4)
     nokogiri (1.15.4-arm64-darwin)
@@ -257,7 +257,7 @@ GEM
       byebug (~> 11.0)
       pry (>= 0.13, < 0.15)
     public_suffix (5.0.1)
-    puma (5.6.7)
+    puma (5.6.8)
       nio4r (~> 2.0)
     raabro (1.4.0)
     racc (1.7.1)

--- a/app/views/schedules/_form.html.erb
+++ b/app/views/schedules/_form.html.erb
@@ -158,7 +158,7 @@
         </div>
 
         <div class='col-2'>
-          <%= form.select :destination_id, options_from_collection_for_select(@destinations, 'id', 'name'), {},
+          <%= form.select :destination_id, options_from_collection_for_select(@destinations, 'id', 'name', @schedule.destination.id), {},
                           class: 'form-select' %>
         </div>
       </div>

--- a/app/views/schedules/_form.html.erb
+++ b/app/views/schedules/_form.html.erb
@@ -158,7 +158,7 @@
         </div>
 
         <div class='col-2'>
-          <%= form.select :destination_id, 
+          <%= form.select :destination_id,
                           options_from_collection_for_select(
                             @destinations, 'id', 'name', @schedule.destination&.id
                           ), {},

--- a/app/views/schedules/_form.html.erb
+++ b/app/views/schedules/_form.html.erb
@@ -158,7 +158,10 @@
         </div>
 
         <div class='col-2'>
-          <%= form.select :destination_id, options_from_collection_for_select(@destinations, 'id', 'name', @schedule.destination.id), {},
+          <%= form.select :destination_id, 
+                          options_from_collection_for_select(
+                            @destinations, 'id', 'name', @schedule.destination&.id
+                          ), {},
                           class: 'form-select' %>
         </div>
       </div>

--- a/app/views/transformation_definitions/show.html.erb
+++ b/app/views/transformation_definitions/show.html.erb
@@ -22,7 +22,7 @@
   <span id='react-nav-tabs'></span>
 <% end %>
 
-<% if @transformation_definition.extraction_job.completed? %>
+<% if @transformation_definition.extraction_job.completed? || @transformation_definition.extraction_job.cancelled? %>
   <div id="js-transformation-app" data-props="<%= @props %>"></div>
 <% else %>
   <div class="container">


### PR DESCRIPTION
### Bug 1: Using a cancelled extraction

### Steps to reproduce
1. Update the settings to use the cancelled extraction job. 
2. Save the modal.

### Expected
You should be able to transform a cancelled extraction.

### Actual
the page does not load fully and gets stuck on 
`Waiting for extraction to run. Please wait a minute and refresh the page.`


----------------------------------------------------------------------------------

--------------------------------------------------------------

### Bug  2: Schedule edit autopopulate

### Steps to reproduce
1. Notice the "destination" before pressing "Edit" on a schedule

### Expected
The page should auto populate with the same "destination" from the previous screen

### Actual
It seems to default to staging (even though it was previously Prod)