### PR TITLE
Fix broken deletion for extraction jobs

### DIFF
--- a/app/models/extraction_definition.rb
+++ b/app/models/extraction_definition.rb
@@ -12,7 +12,7 @@ class ExtractionDefinition < ApplicationRecord
   belongs_to :last_edited_by, class_name: 'User', optional: true
 
   # the before_destroy needs to be here (before any other dependent: :destroy statements)
-  before_destroy :remove_dependent_objects, prepend: true
+  before_destroy :destroy_associated_definitions, prepend: true
 
   has_many :harvest_definitions, dependent: :nullify
   has_many :extraction_jobs, dependent: :destroy
@@ -84,7 +84,7 @@ class ExtractionDefinition < ApplicationRecord
     cloned_extraction_definition
   end
 
-  def remove_dependent_objects
+  def destroy_associated_definitions
     # Remove all associated harvest reports
     extraction_jobs.each do |extraction_job|
       next if extraction_job.harvest_job.blank?

--- a/app/models/extraction_definition.rb
+++ b/app/models/extraction_definition.rb
@@ -80,4 +80,19 @@ class ExtractionDefinition < ApplicationRecord
 
     cloned_extraction_definition
   end
+
+  def destroy
+    # Remove all associated harvest reports
+    extraction_jobs.each do |extraction_job|
+      next if extraction_job.harvest_job.blank?
+
+      extraction_job.harvest_job.harvest_report.destroy!
+      extraction_job.reload
+      extraction_job.harvest_job.destroy!
+    end
+
+    reload
+
+    super
+  end
 end

--- a/app/models/extraction_definition.rb
+++ b/app/models/extraction_definition.rb
@@ -11,9 +11,6 @@ class ExtractionDefinition < ApplicationRecord
   belongs_to :pipeline
   belongs_to :last_edited_by, class_name: 'User', optional: true
 
-  # the before_destroy needs to be here (before any other dependent: :destroy statements)
-  before_destroy :destroy_associated_definitions, prepend: true
-
   has_many :harvest_definitions, dependent: :nullify
   has_many :extraction_jobs, dependent: :destroy
   has_many :requests, dependent: :destroy
@@ -82,18 +79,5 @@ class ExtractionDefinition < ApplicationRecord
     end
 
     cloned_extraction_definition
-  end
-
-  def destroy_associated_definitions
-    # Remove all associated harvest reports
-    extraction_jobs.each do |extraction_job|
-      next if extraction_job.harvest_job.blank?
-
-      extraction_job.harvest_job.harvest_report.destroy!
-      extraction_job.reload
-      extraction_job.harvest_job.destroy!
-    end
-
-    reload
   end
 end

--- a/app/models/extraction_definition.rb
+++ b/app/models/extraction_definition.rb
@@ -11,6 +11,9 @@ class ExtractionDefinition < ApplicationRecord
   belongs_to :pipeline
   belongs_to :last_edited_by, class_name: 'User', optional: true
 
+  # the before_destroy needs to be here (before any other dependent: :destroy statements)
+  before_destroy :remove_dependent_objects, prepend: true
+
   has_many :harvest_definitions, dependent: :nullify
   has_many :extraction_jobs, dependent: :destroy
   has_many :requests, dependent: :destroy
@@ -81,7 +84,7 @@ class ExtractionDefinition < ApplicationRecord
     cloned_extraction_definition
   end
 
-  def destroy
+  def remove_dependent_objects
     # Remove all associated harvest reports
     extraction_jobs.each do |extraction_job|
       next if extraction_job.harvest_job.blank?
@@ -92,7 +95,5 @@ class ExtractionDefinition < ApplicationRecord
     end
 
     reload
-
-    super
   end
 end

--- a/app/models/extraction_job.rb
+++ b/app/models/extraction_job.rb
@@ -10,7 +10,7 @@ class ExtractionJob < ApplicationRecord
   enum :kind, { full: 0, sample: 1 }, prefix: :is
 
   belongs_to :extraction_definition
-  has_one :harvest_job, dependent: :restrict_with_exception
+  has_one :harvest_job, dependent: :destroy
 
   after_create :create_folder
   after_destroy :delete_folder

--- a/app/models/harvest_definition.rb
+++ b/app/models/harvest_definition.rb
@@ -40,7 +40,6 @@ class HarvestDefinition < ApplicationRecord
   def destroy_associated_definitions
     destroy_definition(extraction_definition)
     destroy_definition(transformation_definition)
-    destroy_harvest_reports
   end
 
   def completed_harvest_jobs?

--- a/app/models/harvest_definition.rb
+++ b/app/models/harvest_definition.rb
@@ -61,6 +61,7 @@ class HarvestDefinition < ApplicationRecord
   end
 
   def destroy
+    # Remove all associated harvest reports
     harvest_jobs.each do | harvest_job |
       next if harvest_job.blank? || harvest_job.harvest_report.blank?
 

--- a/app/models/harvest_definition.rb
+++ b/app/models/harvest_definition.rb
@@ -28,7 +28,7 @@ class HarvestDefinition < ApplicationRecord
   end
 
   def destroy_harvest_reports
-    harvest_jobs.each do | harvest_job |
+    harvest_jobs.each do |harvest_job|
       next if harvest_job.blank? || harvest_job.harvest_report.blank?
 
       harvest_job.harvest_report.destroy!

--- a/app/models/harvest_definition.rb
+++ b/app/models/harvest_definition.rb
@@ -59,4 +59,16 @@ class HarvestDefinition < ApplicationRecord
   def clone(pipeline)
     HarvestDefinition.new(dup.attributes.merge(pipeline:))
   end
+
+  def destroy
+    harvest_jobs.each do | harvest_job |
+      next if harvest_job.blank? || harvest_job.harvest_report.blank?
+
+      harvest_job.harvest_report.destroy!
+    end
+
+    reload
+
+    super
+  end
 end

--- a/app/models/harvest_definition.rb
+++ b/app/models/harvest_definition.rb
@@ -27,16 +27,6 @@ class HarvestDefinition < ApplicationRecord
     definition.destroy unless definition.nil? || definition.shared?
   end
 
-  def destroy_harvest_reports
-    harvest_jobs.each do |harvest_job|
-      next if harvest_job.blank? || harvest_job.harvest_report.blank?
-
-      harvest_job.harvest_report.destroy!
-    end
-
-    reload
-  end
-
   def destroy_associated_definitions
     destroy_definition(extraction_definition)
     destroy_definition(transformation_definition)

--- a/app/models/harvest_job.rb
+++ b/app/models/harvest_job.rb
@@ -7,7 +7,7 @@ class HarvestJob < ApplicationRecord
   belongs_to :pipeline_job
   belongs_to :harvest_definition
   belongs_to :extraction_job, optional: true
-  has_one    :harvest_report, dependent: :restrict_with_exception
+  has_one    :harvest_report, dependent: :destroy
 
   delegate :extraction_definition, to: :harvest_definition
   delegate :transformation_definition, to: :harvest_definition

--- a/spec/models/extraction_definition_spec.rb
+++ b/spec/models/extraction_definition_spec.rb
@@ -185,4 +185,44 @@ RSpec.describe ExtractionDefinition do
       expect(cloned_extraction_definition.name).to eq 'clone'
     end
   end
+
+  describe "#destroy" do
+    let!(:pipeline_job)       { create(:pipeline_job, pipeline: pipeline1, destination:) }
+    let!(:harvest_definition) { create(:harvest_definition, pipeline: pipeline1, extraction_definition: subject) }
+    let!(:destination)        { create(:destination) }
+
+    context "when an extraction definition is run as part of a harvest" do
+      let!(:extraction_job)     { create(:extraction_job, extraction_definition: subject, harvest_job:)}
+      let!(:harvest_job)        { create(:harvest_job, :completed, harvest_definition:, pipeline_job:) }
+      let!(:harvest_report)     { create(:harvest_report, pipeline_job:, harvest_job:) }
+
+      it "destroys the extraction definition" do
+        expect {
+          subject.destroy
+        }.to change { ExtractionDefinition.count }.by(-1)
+      end
+
+      it "destroys the harvest job" do
+        expect {
+          subject.destroy
+        }.to change { HarvestJob.count }.by(-1)
+      end
+
+      it "destroys the harvest reports" do
+        expect {
+          subject.destroy
+        }.to change { HarvestReport.count }.by(-1)
+      end
+    end
+
+    context "when an extraction definition doesn't run as part of a harvest" do
+      let!(:extraction_job)     { create(:extraction_job, extraction_definition: subject)}
+
+      it "destroys the extraction definition" do
+        expect {
+          subject.destroy
+        }.to change { ExtractionDefinition.count }.by(-1)
+      end
+    end
+  end
 end

--- a/spec/models/extraction_definition_spec.rb
+++ b/spec/models/extraction_definition_spec.rb
@@ -197,21 +197,15 @@ RSpec.describe ExtractionDefinition do
       let!(:harvest_report)     { create(:harvest_report, pipeline_job:, harvest_job:) }
 
       it "destroys the extraction definition" do
-        expect {
-          subject.destroy
-        }.to change { ExtractionDefinition.count }.by(-1)
+        expect { subject.destroy }.to change(ExtractionDefinition, :count).by(-1)
       end
 
       it "destroys the harvest job" do
-        expect {
-          subject.destroy
-        }.to change { HarvestJob.count }.by(-1)
+        expect { subject.destroy }.to change(HarvestJob, :count).by(-1)
       end
 
       it "destroys the harvest reports" do
-        expect {
-          subject.destroy
-        }.to change { HarvestReport.count }.by(-1)
+        expect { subject.destroy }.to change(HarvestReport, :count).by(-1)
       end
     end
 
@@ -219,9 +213,7 @@ RSpec.describe ExtractionDefinition do
       let!(:extraction_job)     { create(:extraction_job, extraction_definition: subject)}
 
       it "destroys the extraction definition" do
-        expect {
-          subject.destroy
-        }.to change { ExtractionDefinition.count }.by(-1)
+        expect { subject.destroy }.to change(ExtractionDefinition, :count).by(-1)
       end
     end
   end

--- a/spec/models/harvest_definition_spec.rb
+++ b/spec/models/harvest_definition_spec.rb
@@ -152,5 +152,24 @@ RSpec.describe HarvestDefinition do
         expect { harvest_definition.destroy }.to change(TransformationDefinition, :count).by(0)
       end
     end
+
+    context "when a harvest definition has previously been run" do
+      let!(:destination)        { create(:destination) }
+      let!(:pipeline_job)       { create(:pipeline_job, pipeline: pipeline, destination:) }
+      let!(:harvest_job)        { create(:harvest_job, :completed, harvest_definition:, pipeline_job:) }
+      let!(:harvest_report)     { create(:harvest_report, pipeline_job:, harvest_job:) }
+
+      it "destroys the harvest definition" do
+        expect { harvest_definition.destroy }.to change(HarvestDefinition, :count).by(-1)
+      end
+
+      it "destroys the harvest job" do
+        expect { harvest_definition.destroy }.to change(HarvestJob, :count).by(-1)
+      end
+
+      it "destroys the harvest reports" do
+        expect { harvest_definition.destroy }.to change(HarvestReport, :count).by(-1)
+      end
+    end 
   end
 end


### PR DESCRIPTION
Harvest Definitions & Extraction Definitions cannot currently be deleted via the UI due to destroy restrictions.

Have chatted with Richard and updated the harvest jobs to be able to be deleted in the deletion cascade