### PR TITLE
Past jobs can still be viewed when an enrichment definition or harvest definition is removed

### DIFF
--- a/app/models/harvest_job.rb
+++ b/app/models/harvest_job.rb
@@ -7,7 +7,7 @@ class HarvestJob < ApplicationRecord
   belongs_to :pipeline_job
   belongs_to :harvest_definition
   belongs_to :extraction_job, optional: true
-  has_one    :harvest_report, dependent: :destroy
+  has_one    :harvest_report
 
   delegate :extraction_definition, to: :harvest_definition
   delegate :transformation_definition, to: :harvest_definition

--- a/app/models/harvest_job.rb
+++ b/app/models/harvest_job.rb
@@ -7,7 +7,7 @@ class HarvestJob < ApplicationRecord
   belongs_to :pipeline_job
   belongs_to :harvest_definition
   belongs_to :extraction_job, optional: true
-  has_one    :harvest_report
+  has_one    :harvest_report, dependent: nil
 
   delegate :extraction_definition, to: :harvest_definition
   delegate :transformation_definition, to: :harvest_definition

--- a/app/models/harvest_report.rb
+++ b/app/models/harvest_report.rb
@@ -97,7 +97,7 @@ class HarvestReport < ApplicationRecord
   private
 
   def considered_cancelled?
-    statuses.any?('cancelled') || harvest_job.cancelled? || pipeline_job.cancelled?
+    statuses.any?('cancelled') || harvest_job&.cancelled? || pipeline_job.cancelled?
   end
 
   def considered_running?

--- a/app/models/harvest_report.rb
+++ b/app/models/harvest_report.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class HarvestReport < ApplicationRecord
-  belongs_to :pipeline_job
-  belongs_to :harvest_job
+  belongs_to :pipeline_job, optional: true
+  belongs_to :harvest_job, optional: true
 
   STATUSES = %w[queued cancelled running completed errored].freeze
 
@@ -11,9 +11,9 @@ class HarvestReport < ApplicationRecord
   enum :load_status,           STATUSES, prefix: :load
   enum :delete_status,         STATUSES, prefix: :delete
 
-  delegate :harvest_definition, to: :harvest_job
-  delegate :extraction_definition, to: :harvest_job
-  delegate :transformation_definition, to: :harvest_job
+  delegate :harvest_definition, to: :harvest_job, allow_nil: true
+  delegate :extraction_definition, to: :harvest_job, allow_nil: true
+  delegate :transformation_definition, to: :harvest_job, allow_nil: true
 
   enum :kind, { harvest: 0, enrichment: 1 }
 

--- a/app/sidekiq/harvest_worker.rb
+++ b/app/sidekiq/harvest_worker.rb
@@ -5,8 +5,7 @@ class HarvestWorker < ApplicationWorker
     @harvest_job = harvest_job
     @pipeline_job = harvest_job.pipeline_job
 
-    @harvest_report = HarvestReport.create(pipeline_job: @pipeline_job,
-                                           harvest_job: @harvest_job,
+    @harvest_report = HarvestReport.create(pipeline_job: @pipeline_job, harvest_job: @harvest_job,
                                            kind: @harvest_job.harvest_definition.kind,
                                            definition_name: @harvest_job.harvest_definition.name)
 

--- a/app/sidekiq/harvest_worker.rb
+++ b/app/sidekiq/harvest_worker.rb
@@ -5,8 +5,10 @@ class HarvestWorker < ApplicationWorker
     @harvest_job = harvest_job
     @pipeline_job = harvest_job.pipeline_job
 
-    @harvest_report = HarvestReport.create(pipeline_job: @pipeline_job, harvest_job: @harvest_job,
-                                           kind: @harvest_job.harvest_definition.kind)
+    @harvest_report = HarvestReport.create(pipeline_job: @pipeline_job, 
+                                           harvest_job: @harvest_job,
+                                           kind: @harvest_job.harvest_definition.kind, 
+                                           definition_name: @harvest_job.harvest_definition.name)
 
     if @pipeline_job.extraction_job.nil? || @harvest_job.harvest_definition.enrichment?
       create_extraction_job

--- a/app/sidekiq/harvest_worker.rb
+++ b/app/sidekiq/harvest_worker.rb
@@ -5,9 +5,9 @@ class HarvestWorker < ApplicationWorker
     @harvest_job = harvest_job
     @pipeline_job = harvest_job.pipeline_job
 
-    @harvest_report = HarvestReport.create(pipeline_job: @pipeline_job, 
+    @harvest_report = HarvestReport.create(pipeline_job: @pipeline_job,
                                            harvest_job: @harvest_job,
-                                           kind: @harvest_job.harvest_definition.kind, 
+                                           kind: @harvest_job.harvest_definition.kind,
                                            definition_name: @harvest_job.harvest_definition.name)
 
     if @pipeline_job.extraction_job.nil? || @harvest_job.harvest_definition.enrichment?

--- a/app/views/pipeline_jobs/index.html.erb
+++ b/app/views/pipeline_jobs/index.html.erb
@@ -67,7 +67,7 @@
                ) %>
 
               <tr>
-                <td><%= report.harvest_job.name %></td>
+                <td><%= report.definition_name || report.harvest_job.name %></td>
                 <td>
                   <% if pipeline_job.schedule.present? %>
                     Schedule
@@ -90,7 +90,7 @@
                 <td>
                   <i class="bi bi-three-dots-vertical table__control" data-bs-toggle='dropdown'></i>
                   <ul class="dropdown-menu dropdown-menu-end">
-                    <% if report.harvest_job.extraction_job_id.present? %>
+                    <% if report.harvest_job && report.harvest_job.extraction_job_id.present? %>
                       <li>
                         <%= link_to pipeline_harvest_definition_extraction_definition_extraction_job_path(
                               @pipeline.id,

--- a/app/views/pipeline_jobs/index.html.erb
+++ b/app/views/pipeline_jobs/index.html.erb
@@ -88,30 +88,32 @@
                 <td><%= report.records_rejected %></td>
                 <td><%= report.records_deleted %></td>
                 <td>
-                  <i class="bi bi-three-dots-vertical table__control" data-bs-toggle='dropdown'></i>
-                  <ul class="dropdown-menu dropdown-menu-end">
-                    <% if report.harvest_job && report.harvest_job.extraction_job_id.present? %>
-                      <li>
-                        <%= link_to pipeline_harvest_definition_extraction_definition_extraction_job_path(
-                              @pipeline.id,
-                              report.harvest_definition.id,
-                              report.extraction_definition.id,
-                              report.harvest_job.extraction_job_id
-                            ), class: 'dropdown-item' do %>
-                          <i class="bi bi-link-45deg me-2"></i> View Extracted Data
-                        <% end %>
-                      </li>
-                    <% end %>
+                  <% if report.harvest_definition %>
+                    <i class="bi bi-three-dots-vertical table__control" data-bs-toggle='dropdown'></i>
+                    <ul class="dropdown-menu dropdown-menu-end">
+                      <% if report.harvest_job && report.harvest_job.extraction_job_id.present? %>
+                        <li>
+                          <%= link_to pipeline_harvest_definition_extraction_definition_extraction_job_path(
+                                @pipeline.id,
+                                report.harvest_definition.id,
+                                report.extraction_definition.id,
+                                report.harvest_job.extraction_job_id
+                              ), class: 'dropdown-item' do %>
+                            <i class="bi bi-link-45deg me-2"></i> View Extracted Data
+                          <% end %>
+                        </li>
+                      <% end %>
 
-                    <% if report.status == 'running' || report.status == 'queued' %>
-                      <li>
-                        <%= button_to cancel_pipeline_pipeline_job_path(@pipeline.id, report.pipeline_job_id),
-                                      class: 'dropdown-item' do %>
-                          <i class="bi bi-x-circle me-2"></i> Cancel job
-                        <% end %>
-                      </li>
-                    <% end %>
-                  </ul>
+                      <% if report.status == 'running' || report.status == 'queued' %>
+                        <li>
+                          <%= button_to cancel_pipeline_pipeline_job_path(@pipeline.id, report.pipeline_job_id),
+                                        class: 'dropdown-item' do %>
+                            <i class="bi bi-x-circle me-2"></i> Cancel job
+                          <% end %>
+                        </li>
+                      <% end %>
+                    </ul>
+                  <% end %>
                 </td>
               </tr>
           <% else %>

--- a/db/migrate/20240725030305_add_definition_name_to_harvest_report.rb
+++ b/db/migrate/20240725030305_add_definition_name_to_harvest_report.rb
@@ -1,0 +1,5 @@
+class AddDefinitionNameToHarvestReport < ActiveRecord::Migration[7.1]
+  def change
+    add_column :harvest_reports, :definition_name, :string
+  end
+end

--- a/db/migrate/20240725030305_add_definition_name_to_harvest_report.rb
+++ b/db/migrate/20240725030305_add_definition_name_to_harvest_report.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddDefinitionNameToHarvestReport < ActiveRecord::Migration[7.1]
   def change
     add_column :harvest_reports, :definition_name, :string

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_05_06_215031) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_25_030305) do
   create_table "destinations", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "url", null: false
@@ -143,6 +143,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_06_215031) do
     t.timestamp "transformation_updated_time"
     t.timestamp "load_updated_time"
     t.timestamp "delete_updated_time"
+    t.string "definition_name"
     t.index ["harvest_job_id"], name: "index_harvest_reports_on_harvest_job_id"
     t.index ["pipeline_job_id"], name: "index_harvest_reports_on_pipeline_job_id"
   end

--- a/spec/models/extraction_definition_spec.rb
+++ b/spec/models/extraction_definition_spec.rb
@@ -204,8 +204,8 @@ RSpec.describe ExtractionDefinition do
         expect { subject.destroy }.to change(HarvestJob, :count).by(-1)
       end
 
-      it "destroys the harvest reports" do
-        expect { subject.destroy }.to change(HarvestReport, :count).by(-1)
+      it "does not destroy the harvest reports" do
+        expect { subject.destroy }.to change(HarvestReport, :count).by(0)
       end
     end
 

--- a/spec/models/harvest_definition_spec.rb
+++ b/spec/models/harvest_definition_spec.rb
@@ -155,7 +155,7 @@ RSpec.describe HarvestDefinition do
 
     context "when a harvest definition has previously been run" do
       let!(:destination)        { create(:destination) }
-      let!(:pipeline_job)       { create(:pipeline_job, pipeline: pipeline, destination:) }
+      let!(:pipeline_job)       { create(:pipeline_job, pipeline: pipeline, destination:, harvest_definitions_to_run: [harvest_definition.id.to_s]) }
       let!(:harvest_job)        { create(:harvest_job, :completed, harvest_definition:, pipeline_job:) }
       let!(:harvest_report)     { create(:harvest_report, pipeline_job:, harvest_job:) }
 
@@ -167,8 +167,8 @@ RSpec.describe HarvestDefinition do
         expect { harvest_definition.destroy }.to change(HarvestJob, :count).by(-1)
       end
 
-      it "destroys the harvest reports" do
-        expect { harvest_definition.destroy }.to change(HarvestReport, :count).by(-1)
+      it "does not destroy the harvest reports" do
+        expect { harvest_definition.destroy }.to change(HarvestReport, :count).by(0)
       end
     end 
   end

--- a/spec/models/harvest_report_spec.rb
+++ b/spec/models/harvest_report_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe HarvestReport do
-  subject                  { create(:harvest_report, pipeline_job:, harvest_job:) }
+  subject                  { create(:harvest_report, pipeline_job:, harvest_job:, definition_name: harvest_job.harvest_definition.name) }
 
   let(:pipeline)           { create(:pipeline) }
   let(:destination)        { create(:destination) }
@@ -12,7 +12,13 @@ RSpec.describe HarvestReport do
   let(:harvest_job)        { create(:harvest_job, harvest_definition:, pipeline_job:) }
 
   describe 'associations' do
-    it { is_expected.to belong_to(:pipeline_job) }
+    it { is_expected.to belong_to(:pipeline_job).optional }
+  end
+
+  describe '#initialize' do
+    it 'has the same name as its harvest definition' do
+      expect(subject.definition_name).to eq harvest_definition.name
+    end
   end
 
   describe 'status checks' do


### PR DESCRIPTION
Reports were dependent on their enrichment definitions and harvest definitions, and they were being destroyed if the definition was deleted. This meant the reports tab was breaking as the report no longer existed.

We're fixed this by making reports an independent object, which copies the pipeline name that it belongs to (the only piece of data that was missing once the definition had been deleted)