### PR TITLE
ADD FIELD FOCUSED ELEMENT

### DIFF
--- a/app/frontend/js/apps/ExtractionApp/components/Parameter.jsx
+++ b/app/frontend/js/apps/ExtractionApp/components/Parameter.jsx
@@ -284,7 +284,10 @@ const Parameter = ({ id }) => {
                             </option>
                             {map(initialRequestQueryParameters, (parameter) => {
                               return (
-                                <option value={parameter.name} ref={valueInputRef}>
+                                <option
+                                  value={parameter.name}
+                                  ref={valueInputRef}
+                                >
                                   {parameter.name}
                                 </option>
                               );

--- a/app/frontend/js/apps/ExtractionApp/components/Parameter.jsx
+++ b/app/frontend/js/apps/ExtractionApp/components/Parameter.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState, useRef } from "react";
 import { useSelector, useDispatch } from "react-redux";
 import classNames from "classnames";
 import { capitalize, filter, map } from "lodash";
@@ -54,6 +54,17 @@ const Parameter = ({ id }) => {
   const [contentValue, setContentValue] = useState(content);
   const [kindValue] = useState(kind);
   const [showModal, setShowModal] = useState(false);
+
+  const nameInputRef = useRef(null);
+  const contentInputRef = useRef(null);
+
+  useEffect(() => {
+    if (kind === "slug") {
+      contentInputRef.current.focus();
+    } else {
+      nameInputRef.current.focus();
+    }
+  }, [kind]);
 
   const handleSaveClick = () => {
     dispatch(
@@ -257,6 +268,7 @@ const Parameter = ({ id }) => {
                             className="form-control"
                             defaultValue={name}
                             onChange={(e) => setNameValue(e.target.value)}
+                            ref={nameInputRef}
                           />
                         )}
 
@@ -265,13 +277,14 @@ const Parameter = ({ id }) => {
                             className="form-select"
                             defaultValue={name}
                             onChange={(e) => setNameValue(e.target.value)}
+                            ref={nameInputRef}
                           >
                             <option value="">
                               Please select a parameter to be incremented...
                             </option>
                             {map(initialRequestQueryParameters, (parameter) => {
                               return (
-                                <option value={parameter.name}>
+                                <option value={parameter.name} ref={valueInputRef}>
                                   {parameter.name}
                                 </option>
                               );
@@ -306,6 +319,7 @@ const Parameter = ({ id }) => {
                         required="required"
                         defaultValue={contentValue}
                         onChange={(e) => setContentValue(e.target.value)}
+                        ref={contentInputRef}
                       />
                     )}
 

--- a/app/frontend/js/apps/TransformationApp/components/Field.jsx
+++ b/app/frontend/js/apps/TransformationApp/components/Field.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useRef } from "react";
 import { useSelector, useDispatch } from "react-redux";
 import classNames from "classnames";
 import { isEmpty } from "lodash";
@@ -43,6 +43,8 @@ const Field = ({ id }) => {
   const [kindValue, setKindValue] = useState(kind);
   const [blockValue, setBlockValue] = useState(block);
   const [showModal, setShowModal] = useState(false);
+
+  const nameInputRef = useRef(null);
 
   const handleSaveClick = () => {
     dispatch(
@@ -125,6 +127,10 @@ const Field = ({ id }) => {
     if (isEmpty(nameValue)) {
       const element = document.getElementById(`field-${id}`);
       element.scrollIntoView({ behaviour: "smooth" });
+    }
+
+    if (nameInputRef.current) {
+      nameInputRef.current.focus();
     }
   }, []);
 
@@ -216,6 +222,7 @@ const Field = ({ id }) => {
                         required="required"
                         defaultValue={name}
                         onChange={(e) => setNameValue(e.target.value)}
+                        ref={nameInputRef}
                       />
                     </div>
                   </div>

--- a/app/frontend/js/apps/TransformationApp/components/Field.jsx
+++ b/app/frontend/js/apps/TransformationApp/components/Field.jsx
@@ -129,6 +129,7 @@ const Field = ({ id }) => {
       element.scrollIntoView({ behaviour: "smooth" });
     }
 
+    // Focus on the name input field
     if (nameInputRef.current) {
       nameInputRef.current.focus();
     }


### PR DESCRIPTION
As a harvester I want the first action element (text box) within a supplejack field to be focused once i've added it so that I can add fields faster without having to click into the first element

**Acceptance Criteria**
- When a 'supplejack field' is added the first actionable element (right now the field name) is focused for the user

**What we've done**
Made the first field when adding a field (the 'name' field) focused on add as shown below

![Screenshot 2024-08-02 at 11 30 45 AM](https://github.com/user-attachments/assets/8c313d1a-18d9-4ee2-b19e-61c84d15567c)
