### PR TITLE
feat(specify-enrichment-fields): Allow specifying particular fields from the Enrichment to prevent returning unnecessary fields

### DIFF
--- a/app/controllers/extraction_definitions_controller.rb
+++ b/app/controllers/extraction_definitions_controller.rb
@@ -99,7 +99,7 @@ class ExtractionDefinitionsController < ApplicationController
     safe_params = params.require(:extraction_definition).permit(
       :pipeline_id, :name, :format, :base_url, :throttle, :page, :per_page,
       :total_selector, :kind, :destination_id, :source_id, :enrichment_url, :paginated, :split, :split_selector,
-      :extract_text_from_file, :fragment_source_id, :fragment_key, :evaluate_javascript
+      :extract_text_from_file, :fragment_source_id, :fragment_key, :evaluate_javascript, :fields, :include_sub_documents
     )
     merge_last_edited_by(safe_params)
   end

--- a/app/supplejack/extraction/record_extraction.rb
+++ b/app/supplejack/extraction/record_extraction.rb
@@ -20,8 +20,23 @@ module Extraction
       {
         search: active_filter.merge(fragment_filter),
         search_options: { page: @page },
-        api_key: api_source.api_key
-      }
+        api_key: api_source.api_key,
+        record_includes: 
+    }.merge(
+      if @extraction_definition.fields.present?
+        {
+          fields: @extraction_definition.fields.split(','),
+        }
+      else
+        {}
+      end
+    )
+    end
+
+    def record_includes
+      return [] if @extraction_definition.include_sub_documents?
+
+      'null'
     end
 
     def active_filter

--- a/app/views/extraction_definitions/_create_edit_enrichment_modal.html.erb
+++ b/app/views/extraction_definitions/_create_edit_enrichment_modal.html.erb
@@ -174,6 +174,30 @@
                     [%w[No false], %w[Yes true]], model.evaluate_javascript
                   ), {}, class: 'form-select' %>
             </div>
+
+            <div class="col-4">
+              <%= form.label :fields, class: 'form-label' do %>
+                Enrichment fields
+                <span
+                  data-bs-toggle="tooltip"
+                  data-bs-title="Specify the fields that you need from the API as a comma seperated list."><i class="bi bi-question-circle" aria-label="helper text"></i>
+                </span>
+              <% end %>
+            </div>
+            <div class="col-8">
+              <%= form.text_field :fields, class: 'form-control' %>
+            </div>
+
+            <div class="col-4">
+              <%= form.label :include_sub_documents, class: 'form-label' do %>
+                Include Subdocuments
+              <% end %>
+            </div>
+            <div class="col-8">
+              <%= form.select :include_sub_documents, options_for_select(
+                    [%w[No false], %w[Yes true]], model.include_sub_documents
+                  ), {}, class: 'form-select' %>
+            </div>
           </div>
 
           <div class='float-end mt-4'>

--- a/db/migrate/20240912210418_add_fields_and_sub_documents_to_extraction_definition.rb
+++ b/db/migrate/20240912210418_add_fields_and_sub_documents_to_extraction_definition.rb
@@ -1,0 +1,6 @@
+class AddFieldsAndSubDocumentsToExtractionDefinition < ActiveRecord::Migration[7.1]
+  def change
+    add_column :extraction_definitions, :fields, :text
+    add_column :extraction_definitions, :include_sub_documents, :boolean, default: true, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_09_09_234254) do
+ActiveRecord::Schema[7.1].define(version: 2024_09_12_210418) do
   create_table "destinations", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "url", null: false
@@ -43,6 +43,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_09_234254) do
     t.string "fragment_source_id"
     t.string "fragment_key"
     t.boolean "evaluate_javascript", default: false, null: false
+    t.text "fields"
+    t.boolean "include_sub_documents", default: true, null: false
     t.index ["destination_id"], name: "index_extraction_definitions_on_destination_id"
     t.index ["last_edited_by_id"], name: "index_extraction_definitions_on_last_edited_by_id"
     t.index ["name"], name: "index_extraction_definitions_on_name", unique: true

--- a/spec/supplejack/extraction/record_extraction_spec.rb
+++ b/spec/supplejack/extraction/record_extraction_spec.rb
@@ -35,6 +35,16 @@ RSpec.describe Extraction::RecordExtraction do
       end
     end
 
+    context 'when the extraction definition specifies specific fields and subdocuments' do
+      let(:extraction_definition) { create(:extraction_definition, :enrichment, destination:, fields: 'id,internal_identifier', include_sub_documents: false) }
+
+      let(:subject) { described_class.new(request, 1) }
+
+      it 'specifies the requested fields in the API request' do
+        expect(subject.extract).to be_a(Extraction::Document)
+      end
+    end
+
     context 'when the enrichment is scheduled after a harvest' do
       let(:pipeline)           { create(:pipeline, name: 'NLNZCat') }
       let(:pipeline_job)       { create(:pipeline_job, pipeline:, destination:) }


### PR DESCRIPTION
A good example is if you have a fulltext field that you do not need for the enrichment, it gets returned anyway and takes up space in the filesystem and slows down the response. Especially if it is in the merged fragment as well as an embedded fragment.