### PR TITLE
fix: Docker build error and add dockerignore file to repo

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,77 @@
+# Git
+.git
+.gitattributes
+.github
+.gitignore
+
+# Docker
+.dockerignore
+docker-compose.yml
+
+# Logs
+log/*
+*.log
+yarn-debug.log*
+yarn-error.log*
+
+# Environment
+.env
+.env.*
+*.local
+config/application.yml
+config/master.key
+config/credentials.yml.enc
+
+# Cache and temp files
+tmp/*
+/public/assets
+/public/vite*
+/app/assets/builds/*
+
+# Node
+node_modules
+
+# Test and development
+spec
+coverage
+extractions/test/*
+extractions/development/*
+extractions/staging/*
+dev_data
+
+# Documentation and misc
+README.md
+CONTRIBUTING.md
+CODE_OF_CONDUCT.md
+LICENCE
+
+# Code analysis
+.codeclimate.yml
+.codeclimate_diff.yml
+codeclimate_diff_baseline.json
+.reek.yml
+.rubocop.yml
+.erb_lint.yml
+
+# OS files
+.DS_Store
+
+# Editor configs
+.vscode
+.idea
+**/*.swp
+**/*.swo
+app/frontend/jsconfig.json
+
+# Bundle cache
+vendor/cache/*
+
+# Keep empty directories
+!log/.keep
+!tmp/.keep
+!tmp/pids/.keep
+!extractions/test/.keep
+!extractions/development/.keep
+!extractions/staging/.keep
+!extractions/production/.keep
+!app/assets/builds/.keep 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,8 @@ WORKDIR /app
 # Install packages
 RUN apk add --update --no-cache $BUILD_PACKAGES $DEV_PACKAGES $RUBY_PACKAGES
 
-RUN apk add tesseract-ocr tesseract-ocr-data-eng ocrmypdf --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community
+RUN apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/edge/main icu-libs && \
+    apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community tesseract-ocr tesseract-ocr-data-eng ocrmypdf
 
 COPY Gemfile Gemfile.lock ./
 
@@ -21,6 +22,7 @@ RUN gem install bundler -v $(tail -n1 Gemfile.lock) \
     && bundle config set --local without development:test \
     && bundle config set --local path vendor/cache \
     && bundle config set --local build.nokogiri --use-system-libraries \
+    && bundle config set --local build.nio4r --with-cflags="-Wno-error=implicit-function-declaration" \
     && bundle install --jobs=4 --retry=3 \
     # Remove unneeded files (cached *.gem, *.o, *.c)
     && rm -rf $GEM_HOME/cache/*.gem \


### PR DESCRIPTION
```
9 1.598 ERROR: unable to select packages:
------
 > [ 5/11] RUN apk add tesseract-ocr tesseract-ocr-data-eng ocrmypdf --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community:
0.246 fetch https://dl-cdn.alpinelinux.org/alpine/edge/community/x86_64/APKINDEX.tar.gz 0.707 fetch https://dl-cdn.alpinelinux.org/alpine/v3.20/main/x86_64/APKINDEX.tar.gz 1.008 fetch https://dl-cdn.alpinelinux.org/alpine/v3.20/community/x86_64/APKINDEX.tar.gz 1.598 ERROR: unable to select packages:
1.603   so:libicui18n.so.76 (no such package):
1.603     required by: tesseract-ocr-5.5.0-r2[so:libicui18n.so.76]
1.603   so:libicuuc.so.76 (no such package):
1.603     required by: tesseract-ocr-5.5.0-r2[so:libicuuc.so.76]
------

 4 warnings found (use docker --debug to expand):
 - SecretsUsedInArgOrEnv: Do not use ARG or ENV instructions for sensitive data (ARG "RAILS_MASTER_KEY") (line 37)
 - SecretsUsedInArgOrEnv: Do not use ARG or ENV instructions for sensitive data (ENV "RAILS_MASTER_KEY") (line 38)
 - SecretsUsedInArgOrEnv: Do not use ARG or ENV instructions for sensitive data (ARG "RAILS_SECRET_KEY_BASE") (line 39)
 - SecretsUsedInArgOrEnv: Do not use ARG or ENV instructions for sensitive data (ENV "SECRET_KEY_BASE") (line 40) Dockerfile:15
--------------------
  13 |     RUN apk add --update --no-cache $BUILD_PACKAGES $DEV_PACKAGES $RUBY_PACKAGES
  14 |
  15 | >>> RUN apk add tesseract-ocr tesseract-ocr-data-eng ocrmypdf --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community
  16 |
  17 |     COPY Gemfile Gemfile.lock ./
--------------------
ERROR: failed to solve: process "/bin/sh -c apk add tesseract-ocr tesseract-ocr-data-eng ocrmypdf --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community" did not complete successfully: exit code: 6

```