### PR TITLE
Futher Improve stuck jobs

### DIFF
--- a/app/sidekiq/transformation_worker.rb
+++ b/app/sidekiq/transformation_worker.rb
@@ -52,6 +52,9 @@ class TransformationWorker
 
     @harvest_report.transformation_completed!
 
+    @harvest_report.load_completed! if @harvest_report.load_workers_completed?
+    @harvest_report.delete_completed! if @harvest_report.delete_workers_completed?
+
     return unless @harvest_report.delete_workers_queued.zero?
 
     @harvest_report.delete_completed!
@@ -106,7 +109,7 @@ class TransformationWorker
 
   def select_valid_records(records)
     records.select do |record|
-      record['rejection_reasons'].blank? && record['deletion_reasons'].blank? && record['errors'].blank?
+      record['rejection_reasons'].blank? && record['deletion_reasons'].blank?
     end
   end
 


### PR DESCRIPTION
This PR further improves scenarios where jobs could get stuck by

Removing the strict error checking so that records with errors can still be sent to the API (as it was before previous PR). 
Fixed a scenario where the Transformation Worker could finish after the load or delete worker and they weren't being correctly marked as completed.