### PR TITLE
Update how we install OCR My PDF

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,16 +4,13 @@ WORKDIR /app
 
 ARG BUILD_PACKAGES="build-base curl-dev git"
 # AWS CLI is used to run the S3 extraction
-ARG DEV_PACKAGES="bash mysql-client mariadb-dev yaml-dev zlib-dev nodejs yarn libxml2 libxml2-dev libxslt libxslt-dev gmp-dev openjdk8-jre python3 py3-pip aws-cli chromium chromium-chromedriver"
+ARG DEV_PACKAGES="bash mysql-client mariadb-dev yaml-dev zlib-dev nodejs yarn libxml2 libxml2-dev libxslt libxslt-dev gmp-dev openjdk8-jre python3 py3-pip aws-cli chromium chromium-chromedriver icu-libs tesseract-ocr tesseract-ocr-data-eng ocrmypdf"
 ARG RUBY_PACKAGES="tzdata"
 
 WORKDIR /app
 
 # Install packages
 RUN apk add --update --no-cache $BUILD_PACKAGES $DEV_PACKAGES $RUBY_PACKAGES
-
-RUN apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/edge/main icu-libs && \
-    apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community tesseract-ocr tesseract-ocr-data-eng ocrmypdf
 
 COPY Gemfile Gemfile.lock ./
 


### PR DESCRIPTION
There was a recent split of how ffmpeg and ffmpeg6 are installed through Alpine and because we were using main and edge repos this was causing 2 versions to be installed which would cause Docker build to fail with this error:

ERROR: ffmpeg6-libavutil-6.1.2-r7: trying to overwrite usr/lib/libavutil.so.58 owned by ffmpeg-libavutil-6.1.2-r1.