### PR TITLE
Why did this Extraction stop?

### DIFF
--- a/app/controllers/job_completion_summary_controller.rb
+++ b/app/controllers/job_completion_summary_controller.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class JobCompletionSummaryController < ApplicationController
+    before_action :set_job_completion_summary, only: [:show]
+  
+    def index
+      @job_completion_summary = JobCompletionSummary.recent_errors.page(params[:page])
+  
+      if params[:error_type].present?
+        @job_completion_summary = @job_completion_summary.where(error_type: params[:error_type])
+      end
+  
+      return if params[:extraction_id].blank?
+  
+      @job_completion_summary = @job_completion_summary.where(extraction_id: params[:extraction_id])
+    end
+  
+    def show; end
+  
+    private
+  
+    def set_job_completion_summary
+      @job_completion_summary = JobCompletionSummary.find(params[:id])
+    end
+  end

--- a/app/models/job_completion_summary.rb
+++ b/app/models/job_completion_summary.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+class JobCompletionSummary < ApplicationRecord
+    validates :extraction_id, presence: true, uniqueness: true
+    validates :extraction_name, presence: true
+    validates :error_type, presence: true
+    validates :error_details, presence: true
+    validates :error_count, presence: true, numericality: { greater_than_or_equal_to: 0 }
+  
+    scope :by_error_type, ->(type) { where(error_type: type) }
+    scope :recent, -> { order(last_error_at: :desc) }
+    scope :recent_errors, -> { recent }
+    scope :with_errors, -> { where('error_count > 0') }
+  
+    def self.group_by_error_type
+      group(:error_type).count
+    end
+  
+    def self.total_errors
+      sum(:error_count)
+    end
+  
+    def stop_condition?
+      error_type == 'stop condition'
+    end
+  
+    def system_stop_condition?
+      stop_condition? && error_details.any? { |detail| detail.dig('details', 'is_system_condition') }
+    end
+  
+    def user_stop_condition?
+      stop_condition? && !system_stop_condition?
+    end
+  
+    def self.log_error(extraction_id:, extraction_name:, message:, details: {})
+      error_summary = find_or_initialize_by(extraction_id: extraction_id)
+  
+      error_summary.extraction_name = extraction_name
+      error_summary.error_type = 'error'
+  
+      error_entry = {
+        message: message,
+        details: details,
+        timestamp: Time.current.iso8601,
+        worker_class: details[:worker_class],
+        job_id: details[:job_id],
+        harvest_job_id: details[:harvest_job_id],
+        pipeline_job_id: details[:pipeline_job_id],
+        harvest_report_id: details[:harvest_report_id],
+        stack_trace: details[:stack_trace],
+        context: details[:context] || {}
+      }
+  
+      error_summary.error_details = if error_summary.error_details.present?
+                                      error_summary.error_details + [error_entry]
+                                    else
+                                      [error_entry]
+                                    end
+  
+      error_summary.error_count = error_summary.error_details.size
+      error_summary.first_error_at ||= Time.current
+      error_summary.last_error_at = Time.current
+  
+      error_summary.save!
+      error_summary
+    end
+  
+    def self.log_stop_condition_hit(extraction_id:, extraction_name:, stop_condition_name:, stop_condition_content:, details: {})
+      error_summary = find_or_initialize_by(extraction_id: extraction_id)
+  
+      error_summary.extraction_name = extraction_name
+      error_summary.error_type = 'stop condition'
+  
+      # Determine if this is a system or user-defined stop condition
+      is_system_condition = details[:condition_type].present?
+  
+      error_entry = {
+        message: if is_system_condition
+                   "System stop condition '#{stop_condition_name}' was triggered"
+                 else
+                   "Stop condition '#{stop_condition_name}' was triggered"
+                 end,
+        details: details.merge(
+          stop_condition_name: stop_condition_name,
+          stop_condition_content: stop_condition_content,
+          is_system_condition: is_system_condition
+        ),
+        timestamp: Time.current.iso8601
+      }
+  
+      error_summary.error_details = if error_summary.error_details.present?
+                                      error_summary.error_details + [error_entry]
+                                    else
+                                      [error_entry]
+                                    end
+  
+      error_summary.error_count = error_summary.error_details.size
+      error_summary.first_error_at ||= Time.current
+      error_summary.last_error_at = Time.current
+  
+      error_summary.save!
+      error_summary
+    end
+  end
+  

--- a/app/sidekiq/delete_worker.rb
+++ b/app/sidekiq/delete_worker.rb
@@ -42,5 +42,35 @@ class DeleteWorker
     @harvest_report.update(delete_updated_time: Time.zone.now)
   rescue StandardError => e
     Rails.logger.info "DeleteWorker: Delete Excecution error: #{e}" if defined?(Sidekiq)
+    log_delete_worker_error(e, record, destination)
+  end
+
+  def log_delete_worker_error(exception, record, destination)
+    source_id = record.dig('transformed_record', 'source_id') ||
+                @harvest_report&.pipeline_job&.harvest_definitions&.first&.source_id ||
+                'unknown'
+    extraction_name = record.dig('transformed_record', 'job_id') ||
+                      @harvest_report&.pipeline_job&.harvest_definitions&.first&.name ||
+                      'unknown'
+
+    JobCompletionSummary.log_error(
+      extraction_id: source_id,
+      extraction_name: extraction_name,
+      message: "DeleteWorker error: #{exception.class} - #{exception.message}",
+      details: {
+        worker_class: self.class.name,
+        exception_class: exception.class.name,
+        exception_message: exception.message,
+        stack_trace: exception.backtrace&.first(20),
+        record: record,
+        destination_id: destination.id,
+        destination_name: destination.name,
+        harvest_report_id: @harvest_report&.id,
+        timestamp: Time.current.iso8601
+      }
+    )
+  rescue StandardError => e
+    Rails.logger.error "Failed to log delete worker error to JobCompletionSummary: #{e.message}"
   end
 end
+

--- a/app/sidekiq/enrichment_extraction_worker.rb
+++ b/app/sidekiq/enrichment_extraction_worker.rb
@@ -7,5 +7,37 @@ class EnrichmentExtractionWorker
 
   def perform(enrichment_params)
     process_enrichment_extraction(enrichment_params)
+  rescue StandardError => e
+    log_enrichment_extraction_error(e, enrichment_params)
+    raise
+  end
+
+  private
+
+  def log_enrichment_extraction_error(exception, enrichment_params)
+    params = JSON.parse(enrichment_params)
+    extraction_definition = ExtractionDefinition.find(params['extraction_definition_id'])
+
+    return unless extraction_definition&.harvest_definition&.source_id
+
+    JobCompletionSummary.log_error(
+      extraction_id: extraction_definition.harvest_definition.source_id,
+      extraction_name: extraction_definition.harvest_definition.name,
+      message: "EnrichmentExtractionWorker error: #{exception.class} - #{exception.message}",
+      details: {
+        worker_class: self.class.name,
+        exception_class: exception.class.name,
+        exception_message: exception.message,
+        stack_trace: exception.backtrace&.first(20),
+        extraction_job_id: params['extraction_job_id'],
+        extraction_definition_id: params['extraction_definition_id'],
+        harvest_job_id: params['harvest_job_id'],
+        api_record: params['api_record'],
+        page: params['page'],
+        timestamp: Time.current.iso8601
+      }
+    )
+  rescue StandardError => e
+    Rails.logger.error "Failed to log enrichment extraction error to JobCompletionSummary: #{e.message}"
   end
 end

--- a/app/sidekiq/split_worker.rb
+++ b/app/sidekiq/split_worker.rb
@@ -10,6 +10,9 @@ class SplitWorker < FileExtractionWorker
           create_document(records, saved_response)
           @page += 1
         end
+      rescue StandardError => e
+        log_split_worker_error(e, folder, file)
+        raise
       end
     end
   end
@@ -24,5 +27,33 @@ class SplitWorker < FileExtractionWorker
       status: saved_response['status'], response_headers: saved_response['response_headers'],
       body: "<?xml version=\"1.0\"?><root><records>#{records.map(&:to_xml).join}</records></root>"
     ).save("#{@extraction_folder}/#{folder_number(@page)}/#{name_str}__-__#{page_str}.json")
+  end
+
+  private
+
+  def log_split_worker_error(exception, folder, file)
+    return unless @extraction_definition&.harvest_definition&.source_id
+
+    JobCompletionSummary.log_error(
+      extraction_id: @extraction_definition.harvest_definition.source_id,
+      extraction_name: @extraction_definition.harvest_definition.name,
+      message: "SplitWorker error: #{exception.class} - #{exception.message}",
+      details: {
+        worker_class: self.class.name,
+        exception_class: exception.class.name,
+        exception_message: exception.message,
+        stack_trace: exception.backtrace&.first(20),
+        extraction_job_id: @extraction_job.id,
+        extraction_definition_id: @extraction_definition.id,
+        harvest_job_id: @extraction_job.harvest_job&.id,
+        harvest_report_id: @extraction_job.harvest_job&.harvest_report&.id,
+        folder: folder,
+        file: file,
+        split_selector: @extraction_definition.split_selector,
+        timestamp: Time.current.iso8601
+      }
+    )
+  rescue StandardError => e
+    Rails.logger.error "Failed to log split worker error to JobCompletionSummary: #{e.message}"
   end
 end

--- a/app/sidekiq/text_extraction_worker.rb
+++ b/app/sidekiq/text_extraction_worker.rb
@@ -10,6 +10,9 @@ class TextExtractionWorker < FileExtractionWorker
         filepath = "#{@extraction_folder}/#{folder}/#{file}"
         create_document(extracted_text[:text], filepath, extracted_text[:process])
         @page += 1
+      rescue StandardError => e
+        log_text_extraction_error(e, folder, file)
+        raise
       end
     end
 
@@ -55,8 +58,33 @@ class TextExtractionWorker < FileExtractionWorker
       'OCR failed'
     end
   end
-
   def saved_response
     { 'method' => 'GET', 'status' => 200, 'response_headers' => [], 'request_headers' => [] }
+  end
+
+  def log_text_extraction_error(exception, folder, file)
+    return unless @extraction_definition&.harvest_definition&.source_id
+
+    JobCompletionSummary.log_error(
+      extraction_id: @extraction_definition.harvest_definition.source_id,
+      extraction_name: @extraction_definition.harvest_definition.name,
+      message: "TextExtractionWorker error: #{exception.class} - #{exception.message}",
+      details: {
+        worker_class: self.class.name,
+        exception_class: exception.class.name,
+        exception_message: exception.message,
+        stack_trace: exception.backtrace&.first(20),
+        extraction_job_id: @extraction_job.id,
+        extraction_definition_id: @extraction_definition.id,
+        harvest_job_id: @extraction_job.harvest_job&.id,
+        harvest_report_id: @extraction_job.harvest_job&.harvest_report&.id,
+        folder: folder,
+        file: file,
+        file_extension: File.extname(file),
+        timestamp: Time.current.iso8601
+      }
+    )
+  rescue StandardError => e
+    Rails.logger.error "Failed to log text extraction error to JobCompletionSummary: #{e.message}"
   end
 end

--- a/app/supplejack/extraction/enrichment_execution.rb
+++ b/app/supplejack/extraction/enrichment_execution.rb
@@ -19,6 +19,9 @@ module Extraction
         api_records = JSON.parse(api_document.body)['records']
         extract_and_save_enrichment_documents(api_records)
       end
+    rescue StandardError => e
+      log_enrichment_error(e)
+      raise
     end
 
     private
@@ -42,7 +45,6 @@ module Extraction
 
     def process_enrichment(enrichment_params)
       json_params = enrichment_params.to_json
-
       if @harvest_job&.pipeline_job&.run_enrichment_concurrently?
         EnrichmentExtractionWorker.perform_async_with_priority(@harvest_job.pipeline_job.job_priority, json_params)
       else
@@ -54,9 +56,31 @@ module Extraction
     def throttle
       sleep @extraction_definition.throttle / 1000.0
     end
-
     def page_from_index(index)
       ((@extraction_definition.page - 1) * @extraction_definition.per_page) + (index + 1)
+    end
+
+    def log_enrichment_error(exception)
+      return unless @extraction_definition&.harvest_definition&.source_id
+
+      JobCompletionSummary.log_error(
+        extraction_id: @extraction_definition.harvest_definition.source_id,
+        extraction_name: @extraction_definition.harvest_definition.name,
+        message: "Enrichment execution error: #{exception.class} - #{exception.message}",
+        details: {
+          worker_class: self.class.name,
+          exception_class: exception.class.name,
+          exception_message: exception.message,
+          stack_trace: exception.backtrace&.first(20),
+          extraction_job_id: @extraction_job.id,
+          extraction_definition_id: @extraction_definition.id,
+          harvest_job_id: @harvest_job&.id,
+          harvest_report_id: @harvest_report&.id,
+          timestamp: Time.current.iso8601
+        }
+      )
+    rescue StandardError => e
+      Rails.logger.error "Failed to log enrichment error to JobCompletionSummary: #{e.message}"
     end
   end
 end

--- a/app/views/job_completion_summary/index.html.erb
+++ b/app/views/job_completion_summary/index.html.erb
@@ -1,0 +1,99 @@
+<%= content_for(:title) { 'Job Completion Summary' } %>
+
+<%= content_for(:header) do %>
+  <%= render 'shared/breadcrumb_nav' %>
+
+  <div class='float-start'>
+    <h1>Job Completion Summary</h1>
+    <p>View and manage job completion summary</p>
+  </div>
+
+  <div class='clearfix'></div>
+<% end %>
+
+<div class="row">
+  <div class="col-md-12">
+    <div class="card">
+      <div class="card-header d-flex justify-content-between align-items-center">
+        <h5 class="card-title mb-0">Job completion summary</h5>
+        <span class="badge bg-secondary"><%= @job_completion_summary.total_count %> total</span>
+      </div>
+      <div class="card-body p-0">
+        <% if @job_completion_summary.any? %>
+          <div class="table-responsive">
+            <table class="table table-hover mb-0">
+              <thead class="table-light">
+                <tr>
+                  <th>Extraction ID</th>
+                  <th>Extraction Name</th>
+                  <th>Type</th>
+                  <th>Count</th>
+                  <th>First Occurrence</th>
+                  <th>Last Occurrence</th>
+                  <th>Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                <% @job_completion_summary.each do |error_summary| %>
+                  <tr>
+                    <td>
+                      <code><%= error_summary.extraction_id %></code>
+                    </td>
+                    <td>
+                      <strong><%= error_summary.extraction_name %></strong>
+                    </td>
+                    <td>
+                      <% if error_summary.stop_condition? %>
+                        <% if error_summary.system_stop_condition? %>
+                          <span class="badge bg-info">System Stop Condition</span>
+                        <% else %>
+                          <span class="badge bg-info">User Stop Condition</span>
+                        <% end %>
+                      <% else %>
+                        <span class="badge bg-danger"><%= error_summary.error_type.capitalize %></span>
+                      <% end %>
+                    </td>
+                    <td>
+                      <span class="badge bg-warning text-dark">
+                        <%= error_summary.error_count %>
+                      </span>
+                    </td>
+                    <td>
+                      <small class="text-muted">
+                        <%= error_summary.first_error_at&.strftime("%Y-%m-%d %H:%M:%S") || 'N/A' %>
+                      </small>
+                    </td>
+                    <td>
+                      <small class="text-muted">
+                        <%= error_summary.last_error_at&.strftime("%Y-%m-%d %H:%M:%S") || 'N/A' %>
+                      </small>
+                    </td>
+                    <td>
+                      <%= link_to "View Details", 
+                          job_completion_summary_path(error_summary), 
+                          class: "btn btn-sm btn-outline-primary" %>
+                    </td>
+                  </tr>
+                <% end %>
+              </tbody>
+            </table>
+          </div>
+        <% else %>
+          <div class="text-center py-5">
+            <i class="bi bi-check-circle text-success" style="font-size: 3rem;"></i>
+            <h4 class="mt-3">No Job completion summary Found</h4>
+            <p class="text-muted">There are no job completion summary matching your criteria.</p>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>
+
+<% if @job_completion_summary.any? %>
+  <div class="row mt-3">
+    <div class="col-md-12">
+      <%= render 'shared/pagination_below_table', items: @job_completion_summary %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/job_completion_summary/show.html.erb
+++ b/app/views/job_completion_summary/show.html.erb
@@ -1,0 +1,173 @@
+<%= content_for(:title) { "Job Completion Summary - #{@job_completion_summary.extraction_name}" } %>
+
+<%= content_for(:header) do %>
+  <%= render 'shared/breadcrumb_nav' %>
+
+  <div class='float-start'>
+    <h1>Job Completion Summary Details</h1>
+    <p><%= @job_completion_summary.extraction_name %> (<%= @job_completion_summary.extraction_id %>)</p>
+  </div>
+
+  <div class='clearfix'></div>
+<% end %>
+
+<div class="row">
+  <div class="col-md-8">
+    <div class="card">
+      <div class="card-header d-flex justify-content-between align-items-center">
+        <h5 class="card-title mb-0">Details</h5>
+        <div>
+          <% if @job_completion_summary.stop_condition? %>
+            <% if @job_completion_summary.system_stop_condition? %>
+              <span class="badge bg-info me-2">System Stop Condition</span>
+            <% else %>
+              <span class="badge bg-info me-2">User Stop Condition</span>
+            <% end %>
+          <% else %>
+            <span class="badge bg-danger me-2"><%= @job_completion_summary.error_type.capitalize %></span>
+          <% end %>
+          <span class="badge bg-warning text-dark">
+            <%= @job_completion_summary.error_count %> errors
+          </span>
+        </div>
+      </div>
+      <div class="card-body">
+        <% if @job_completion_summary.error_details.any? %>
+          <div class="accordion" id="errorsAccordion">
+            <% @job_completion_summary.error_details.each_with_index do |error, index| %>
+              <div class="accordion-item">
+                <h2 class="accordion-header" id="heading<%= index %>">
+                  <button class="accordion-button <%= 'collapsed' unless index == 0 %>" 
+                          type="button" 
+                          data-bs-toggle="collapse" 
+                          data-bs-target="#collapse<%= index %>" 
+                          aria-expanded="<%= index == 0 ? 'true' : 'false' %>" 
+                          aria-controls="collapse<%= index %>">
+                    <div class="d-flex justify-content-between align-items-center w-100 me-3">
+                      <div>
+                        <%= error['message']&.truncate(100) || 'No message' %>
+                        <% if error.dig('details', 'is_system_condition') %>
+                          <span class="badge bg-secondary ms-2">System</span>
+                        <% else %>
+                          <span class="badge bg-info ms-2">User-defined</span>
+                        <% end %>
+                      </div>
+                      <small class="text-muted">
+                        <%= Time.parse(error['timestamp']).strftime("%Y-%m-%d %H:%M:%S") rescue 'Unknown time' %>
+                      </small>
+                    </div>
+                  </button>
+                </h2>
+                <div id="collapse<%= index %>" 
+                     class="accordion-collapse collapse <%= 'show' if index == 0 %>" 
+                     aria-labelledby="heading<%= index %>" 
+                     data-bs-parent="#errorsAccordion">
+                  <div class="accordion-body">
+                    <div class="row">
+                      <div class="col-md-12">
+                        <h6>Stop Condition Details:</h6>
+                        <div class="bg-light p-3 rounded">
+                          <p><strong>Name:</strong> <%= error.dig('details', 'stop_condition_name') %></p>
+                          <p><strong>Content:</strong> <%= error.dig('details', 'stop_condition_content') %></p>
+                          <p><strong>Type:</strong> 
+                            <% if error.dig('details', 'is_system_condition') %>
+                              <span class="badge bg-secondary">System Stop Condition</span>
+                            <% else %>
+                              <span class="badge bg-info">User-defined Stop Condition</span>
+                            <% end %>
+                          </p>
+                        </div>
+                      </div>
+                    </div>
+                    <% if error['details'].present? %>
+                      <div class="row mt-3">
+                        <div class="col-md-12">
+                          <h6>Additional Details:</h6>
+                          <pre class="bg-light p-3 rounded"><%= JSON.pretty_generate(error['details']) rescue error['details'].to_s %></pre>
+                        </div>
+                      </div>
+                    <% end %>
+                    <div class="row mt-3">
+                      <div class="col-md-6">
+                        <strong>Occurred At:</strong> 
+                        <%= Time.parse(error['timestamp']).strftime("%Y-%m-%d %H:%M:%S") rescue 'Unknown time' %>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            <% end %>
+          </div>
+        <% else %>
+          <div class="text-center py-4">
+            <i class="bi bi-info-circle text-info" style="font-size: 2rem;"></i>
+            <p class="mt-2 text-muted">No error details available.</p>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+
+  <div class="col-md-4">
+    <div class="card">
+      <div class="card-header">
+        <h5 class="card-title mb-0">Summary Information</h5>
+      </div>
+      <div class="card-body">
+        <dl class="row">
+          <dt class="col-sm-4">Extraction ID:</dt>
+          <dd class="col-sm-8">
+            <code><%= @job_completion_summary.extraction_id %></code>
+          </dd>
+          
+          <dt class="col-sm-4">Extraction Name:</dt>
+          <dd class="col-sm-8">
+            <strong><%= @job_completion_summary.extraction_name %></strong>
+          </dd>
+          
+          <dt class="col-sm-4">Error Type:</dt>
+          <dd class="col-sm-8">
+            <% if @job_completion_summary.stop_condition? %>
+              <% if @job_completion_summary.system_stop_condition? %>
+                <span class="badge bg-info">System Stop Condition</span>
+              <% else %>
+                <span class="badge bg-info">User Stop Condition</span>
+              <% end %>
+            <% else %>
+              <span class="badge bg-danger"><%= @job_completion_summary.error_type.capitalize %></span>
+            <% end %>
+          </dd>
+          
+          <dt class="col-sm-4">Total Errors:</dt>
+          <dd class="col-sm-8">
+            <span class="badge bg-warning text-dark">
+              <%= @job_completion_summary.error_count %>
+            </span>
+          </dd>
+          
+          <dt class="col-sm-4">First Error:</dt>
+          <dd class="col-sm-8">
+            <small class="text-muted">
+              <%= @job_completion_summary.first_error_at&.strftime("%Y-%m-%d %H:%M:%S") || 'N/A' %>
+            </small>
+          </dd>
+          
+          <dt class="col-sm-4">Last Error:</dt>
+          <dd class="col-sm-8">
+            <small class="text-muted">
+              <%= @job_completion_summary.last_error_at&.strftime("%Y-%m-%d %H:%M:%S") || 'N/A' %>
+            </small>
+          </dd>
+        </dl>
+      </div>
+    </div>
+
+    <div class="card mt-3">
+      <div class="card-body text-center">
+        <%= link_to "Back to Job Completion Summary", 
+            job_completion_summary_index_path, 
+            class: "btn btn-outline-primary" %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/shared/_nav.html.erb
+++ b/app/views/shared/_nav.html.erb
@@ -1,32 +1,7 @@
-<nav class="<%= class_names('navbar navbar-expand-md', {
-                              'navbar-dark bg-dark' => %w[production test].include?(Rails.env),
-                              'navbar-light bg-light border-bottom border-2' => %w[production test].exclude?(Rails.env)
-                            }) %>">
-  <div class="container-fluid">
-    <%= link_to root_path, class: 'navbar-brand' do %>
-      <img src="<%= "/logo-#{Rails.env}.svg" %>" alt="Supplejack" height="20">
-    <% end %>
-
-    <button
-      class="navbar-toggler"
-      type="button"
-      data-bs-toggle="collapse"
-      data-bs-target="#navbar-nav"
-      aria-controls="navbar-nav"
-      aria-expanded="false"
-      aria-label="Toggle navigation">
-      <span class="navbar-toggler-icon"></span>
-    </button>
-
-    <% pipelines_classes = class_names('nav-link', active: request.path.include?('pipelines')) %>
-    <% destinations_classes = class_names('nav-link', active: request.path.include?('destinations')) %>
-    <% schemas_classes = class_names('nav-link', active: request.path.include?('schemas')) %>
-    <% display_automations = request.path.include?('automations') && request.path.exclude?('automation_templates') %>
-    <% automations_classes = class_names('nav-link',
-                                         active: display_automations) %>
-    <% automation_templates_classes = class_names('nav-link', active: request.path.include?('automation_templates')) %>
+<% automation_templates_classes = class_names('nav-link', active: request.path.include?('automation_templates')) %>
     <% schedules_classes = class_names('nav-link', active: request.path == '/schedules') %>
     <% jobs_classes = class_names('nav-link', active: request.path == '/jobs') %>
+     <% error_summary_classes = class_names('nav-link', active: request.path.include?('job_completion_summary')) %>
 
     <div class="collapse navbar-collapse justify-content-between" id="navbar-nav">
       <ul class="navbar-nav">
@@ -48,6 +23,9 @@
           </li>
           <li class="nav-item">
             <%= link_to 'Jobs', jobs_path, class: jobs_classes %>
+          </li>
+          <li class="nav-item">
+            <%= link_to 'Job Completion Summary', job_completion_summary_index_path, class: error_summary_classes %>
           </li>
         <% end %>
       </ul>

--- a/db/migrate/20250918235838_create_job_completion_summary.rb
+++ b/db/migrate/20250918235838_create_job_completion_summary.rb
@@ -1,0 +1,24 @@
+class CreateJobCompletionSummary < ActiveRecord::Migration[7.2]
+  def change
+    # Only create table if it doesn't exist
+    unless table_exists?(:job_completion_summaries)
+      create_table :job_completion_summaries do |t|
+        t.string :extraction_id, null: false
+        t.string :extraction_name, null: false
+        t.string :error_type, null: false
+        t.json :error_details, null: false
+        t.integer :error_count, default: 0
+        t.datetime :first_error_at
+        t.datetime :last_error_at
+        t.timestamps
+      end
+      
+      add_index :job_completion_summaries, :extraction_id, unique: true
+      add_index :job_completion_summaries, :error_type
+      add_index :job_completion_summaries, :first_error_at
+      add_index :job_completion_summaries, :last_error_at
+    else
+      puts "Table job_completion_summaries already exists, skipping creation"
+    end
+  end
+end

--- a/db/migrate/20250918235839_rename_job_error_summary_to_job_completion_summary.rb
+++ b/db/migrate/20250918235839_rename_job_error_summary_to_job_completion_summary.rb
@@ -1,0 +1,11 @@
+class RenameJobErrorSummaryToJobCompletionSummary < ActiveRecord::Migration[7.2]
+  def change
+    # Check if the source table exists before attempting to rename
+    if table_exists?(:job_error_summaries) && !table_exists?(:job_completion_summaries)
+      rename_table :job_error_summaries, :job_completion_summaries
+    elsif table_exists?(:job_completion_summaries)
+      # Table already exists with correct name, no action needed
+      puts "Table job_completion_summaries already exists, skipping rename"
+    end
+  end
+end

--- a/db/migrate/20250919015511_update_error_types_in_job_completion_summary.rb
+++ b/db/migrate/20250919015511_update_error_types_in_job_completion_summary.rb
@@ -1,0 +1,13 @@
+class UpdateErrorTypesInJobCompletionSummary < ActiveRecord::Migration[7.2]
+  def up
+    # Update existing records to use new error type labels
+    execute "UPDATE job_completion_summaries SET error_type = 'error' WHERE error_type = 'unplanned'"
+    execute "UPDATE job_completion_summaries SET error_type = 'stop condition' WHERE error_type = 'planned'"
+  end
+
+  def down
+    # Revert back to old error type labels
+    execute "UPDATE job_completion_summaries SET error_type = 'unplanned' WHERE error_type = 'error'"
+    execute "UPDATE job_completion_summaries SET error_type = 'planned' WHERE error_type = 'stop condition'"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_09_01_031216) do
+ActiveRecord::Schema[7.2].define(version: 2025_09_19_015511) do
   create_table "api_response_reports", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "automation_step_id", null: false
     t.string "status", default: "not_started", null: false
@@ -94,7 +94,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_09_01_031216) do
   end
 
   create_table "extraction_definitions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.string "name"
+    t.text "name"
     t.string "format"
     t.text "base_url"
     t.integer "throttle", default: 0, null: false
@@ -102,14 +102,14 @@ ActiveRecord::Schema[7.1].define(version: 2025_09_01_031216) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "kind", default: 0
+    t.string "source_id"
     t.bigint "destination_id"
+    t.bigint "pipeline_id"
     t.integer "page", default: 1
+    t.string "total_selector"
+    t.integer "per_page"
     t.boolean "paginated"
     t.bigint "last_edited_by_id"
-    t.bigint "pipeline_id"
-    t.string "source_id"
-    t.integer "per_page"
-    t.string "total_selector"
     t.boolean "split", default: false, null: false
     t.string "split_selector"
     t.boolean "extract_text_from_file", default: false, null: false
@@ -120,7 +120,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_09_01_031216) do
     t.boolean "include_sub_documents", default: true, null: false
     t.index ["destination_id"], name: "index_extraction_definitions_on_destination_id"
     t.index ["last_edited_by_id"], name: "index_extraction_definitions_on_last_edited_by_id"
-    t.index ["name"], name: "index_extraction_definitions_on_name", unique: true
+    t.index ["name"], name: "index_extraction_definitions_on_name", unique: true, length: 255
     t.index ["pipeline_id"], name: "index_extraction_definitions_on_pipeline_id"
   end
 
@@ -129,11 +129,11 @@ ActiveRecord::Schema[7.1].define(version: 2025_09_01_031216) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "extraction_definition_id", null: false
+    t.integer "kind", default: 0, null: false
     t.timestamp "start_time"
     t.timestamp "end_time"
     t.text "error_message"
     t.text "name"
-    t.integer "kind"
     t.index ["extraction_definition_id"], name: "index_extraction_jobs_on_extraction_definition_id"
     t.index ["status"], name: "index_extraction_jobs_on_status"
   end
@@ -160,7 +160,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_09_01_031216) do
   end
 
   create_table "harvest_definitions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.string "name"
+    t.text "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "extraction_definition_id"
@@ -186,13 +186,15 @@ ActiveRecord::Schema[7.1].define(version: 2025_09_01_031216) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "harvest_definition_id"
+    t.bigint "extraction_job_id"
     t.text "name"
     t.string "key"
     t.string "target_job_id"
-    t.integer "pipeline_job_id"
-    t.integer "extraction_job_id"
+    t.bigint "pipeline_job_id"
+    t.index ["extraction_job_id"], name: "index_harvest_jobs_on_extraction_job_id"
     t.index ["harvest_definition_id"], name: "index_harvest_jobs_on_harvest_definition_id"
     t.index ["key"], name: "index_harvest_jobs_on_key", unique: true
+    t.index ["pipeline_job_id"], name: "index_harvest_jobs_on_pipeline_job_id"
     t.index ["status"], name: "index_harvest_jobs_on_status"
   end
 
@@ -233,6 +235,22 @@ ActiveRecord::Schema[7.1].define(version: 2025_09_01_031216) do
     t.string "definition_name"
     t.index ["harvest_job_id"], name: "index_harvest_reports_on_harvest_job_id"
     t.index ["pipeline_job_id"], name: "index_harvest_reports_on_pipeline_job_id"
+  end
+
+  create_table "job_completion_summaries", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "extraction_id", null: false
+    t.string "extraction_name", null: false
+    t.string "error_type", null: false
+    t.json "error_details", null: false
+    t.integer "error_count", default: 0
+    t.datetime "first_error_at"
+    t.datetime "last_error_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["error_type"], name: "index_job_completion_summaries_on_error_type"
+    t.index ["extraction_id"], name: "index_job_completion_summaries_on_extraction_id", unique: true
+    t.index ["first_error_at"], name: "index_job_completion_summaries_on_first_error_at"
+    t.index ["last_error_at"], name: "index_job_completion_summaries_on_last_error_at"
   end
 
   create_table "parameters", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
@@ -353,7 +371,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_09_01_031216) do
   end
 
   create_table "transformation_definitions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.string "name"
+    t.text "name"
     t.string "record_selector"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -363,7 +381,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_09_01_031216) do
     t.bigint "last_edited_by_id"
     t.index ["extraction_job_id"], name: "index_transformation_definitions_on_extraction_job_id"
     t.index ["last_edited_by_id"], name: "index_transformation_definitions_on_last_edited_by_id"
-    t.index ["name"], name: "index_transformation_definitions_on_name", unique: true
+    t.index ["name"], name: "index_transformation_definitions_on_name", unique: true, length: 255
     t.index ["pipeline_id"], name: "index_transformation_definitions_on_pipeline_id"
   end
 
@@ -403,9 +421,6 @@ ActiveRecord::Schema[7.1].define(version: 2025_09_01_031216) do
     t.index ["unlock_token"], name: "index_users_on_unlock_token", unique: true
   end
 
-  add_foreign_key "api_response_reports", "automation_steps"
-  add_foreign_key "automation_step_templates", "automation_templates"
-  add_foreign_key "automation_step_templates", "pipelines"
   add_foreign_key "automation_steps", "automations"
   add_foreign_key "automation_steps", "pipelines"
   add_foreign_key "automation_steps", "users", column: "launched_by_id"

--- a/spec/factories/job_completion_summary.rb
+++ b/spec/factories/job_completion_summary.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+    factory :job_completion_summary do
+      extraction_id { SecureRandom.uuid }
+      extraction_name { "Test Extraction #{SecureRandom.hex(4)}" }
+      error_type { "error" }
+      error_count { 1 }
+      first_error_at { Time.current }
+      last_error_at { Time.current }
+      error_details do
+        [
+          {
+            "message" => "Test error message",
+            "details" => {
+              "worker_class" => "TestWorker",
+              "job_id" => SecureRandom.hex(8),
+              "context" => { "test" => true }
+            },
+            "timestamp" => Time.current.iso8601
+          }
+        ]
+      end
+  
+      trait :stop_condition do
+        error_type { "stop condition" }
+        error_details do
+          [
+            {
+              "message" => "Stop condition 'test_condition' was triggered",
+              "details" => {
+                "stop_condition_name" => "test_condition",
+                "stop_condition_content" => "if records.count > 100",
+                "condition_type" => "stop_condition"
+              },
+              "timestamp" => Time.current.iso8601
+            }
+          ]
+        end
+      end
+  
+      trait :multiple_errors do
+        error_count { 3 }
+        error_details do
+          [
+            {
+              "message" => "First error",
+              "details" => { "worker_class" => "Worker1" },
+              "timestamp" => 3.hours.ago.iso8601
+            },
+            {
+              "message" => "Second error", 
+              "details" => { "worker_class" => "Worker2" },
+              "timestamp" => 2.hours.ago.iso8601
+            },
+            {
+              "message" => "Third error",
+              "details" => { "worker_class" => "Worker3" },
+              "timestamp" => 1.hour.ago.iso8601
+            }
+          ]
+        end
+      end
+  
+      trait :no_errors do
+        error_count { 0 }
+        error_details { [{"message" => "", "details" => {}, "timestamp" => Time.current.iso8601}] }  # Empty structure to satisfy validation
+      end
+    end
+  end
+  

--- a/spec/models/job_completion_summary_spec.rb
+++ b/spec/models/job_completion_summary_spec.rb
@@ -1,0 +1,262 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe JobCompletionSummary do
+  describe 'validations' do
+    subject { build(:job_completion_summary) }
+
+    it { is_expected.to validate_presence_of(:extraction_id) }
+    it { is_expected.to validate_uniqueness_of(:extraction_id).case_insensitive }
+    it { is_expected.to validate_presence_of(:extraction_name) }
+    it { is_expected.to validate_presence_of(:error_type) }
+    it { is_expected.to validate_presence_of(:error_details) }
+    it { is_expected.to validate_presence_of(:error_count) }
+    it { is_expected.to validate_numericality_of(:error_count).is_greater_than_or_equal_to(0) }
+  end
+
+  describe 'scopes' do
+    let!(:old_summary) { create(:job_completion_summary, last_error_at: 1.day.ago) }
+    let!(:error_summary) { create(:job_completion_summary, error_type: 'error', last_error_at: 2.hours.ago) }
+    let!(:stop_condition_summary) { create(:job_completion_summary, :stop_condition, last_error_at: 3.hours.ago) }
+    let!(:summary_with_errors) { create(:job_completion_summary, error_count: 5, last_error_at: 4.hours.ago) }
+    let!(:summary_no_errors) { create(:job_completion_summary, :no_errors, last_error_at: 5.hours.ago) }
+
+    describe '.by_error_type' do
+      it 'filters by error type' do
+        expect(described_class.by_error_type('error')).to include(error_summary)
+        expect(described_class.by_error_type('error')).not_to include(stop_condition_summary)
+        expect(described_class.by_error_type('stop condition')).to include(stop_condition_summary)
+        expect(described_class.by_error_type('stop condition')).not_to include(error_summary)
+      end
+    end
+  end
+
+  describe 'class methods' do
+    describe '.group_by_error_type' do
+      let!(:error_summary1) { create(:job_completion_summary, error_type: 'error') }
+      let!(:error_summary2) { create(:job_completion_summary, error_type: 'error') }
+      let!(:stop_condition_summary) { create(:job_completion_summary, :stop_condition) }
+
+      it 'groups summaries by error type and counts them' do
+        result = described_class.group_by_error_type
+        expect(result['error']).to eq(2)
+        expect(result['stop condition']).to eq(1)
+      end
+    end
+
+    describe '.total_errors' do
+      let!(:summary1) { create(:job_completion_summary, error_count: 3) }
+      let!(:summary2) { create(:job_completion_summary, error_count: 2) }
+      let!(:summary3) { create(:job_completion_summary, :no_errors) }
+
+      it 'sums all error counts' do
+        expect(described_class.total_errors).to eq(5)
+      end
+    end
+
+    describe '.log_error' do
+      let(:extraction_id) { SecureRandom.uuid }
+      let(:extraction_name) { 'Test Extraction' }
+      let(:message) { 'Test error message' }
+      let(:details) do
+        {
+          worker_class: 'TestWorker',
+          job_id: 'job_123',
+          harvest_job_id: 'harvest_456',
+          pipeline_job_id: 'pipeline_789',
+          harvest_report_id: 'report_101',
+          stack_trace: 'Error: test error',
+          context: { test: true }
+        }
+      end
+
+      context 'when creating a new error summary' do
+        it 'creates a new JobCompletionSummary with error details' do
+          expect {
+            described_class.log_error(
+              extraction_id: extraction_id,
+              extraction_name: extraction_name,
+              message: message,
+              details: details
+            )
+          }.to change(described_class, :count).by(1)
+
+          summary = described_class.last
+          expect(summary.extraction_id).to eq(extraction_id)
+          expect(summary.extraction_name).to eq(extraction_name)
+          expect(summary.error_type).to eq('error')
+          expect(summary.error_count).to eq(1)
+          expect(summary.first_error_at).to be_present
+          expect(summary.last_error_at).to be_present
+        end
+
+        it 'stores error details correctly' do
+          summary = described_class.log_error(
+            extraction_id: extraction_id,
+            extraction_name: extraction_name,
+            message: message,
+            details: details
+          )
+
+          error_entry = summary.error_details.first
+          expect(error_entry['message']).to eq(message)
+          expect(error_entry['details']).to eq(details.deep_stringify_keys)
+          expect(error_entry['timestamp']).to be_present
+          expect(error_entry['worker_class']).to eq('TestWorker')
+          expect(error_entry['job_id']).to eq('job_123')
+          expect(error_entry['harvest_job_id']).to eq('harvest_456')
+          expect(error_entry['pipeline_job_id']).to eq('pipeline_789')
+          expect(error_entry['harvest_report_id']).to eq('report_101')
+          expect(error_entry['stack_trace']).to eq('Error: test error')
+          expect(error_entry['context']).to eq({ "test" => true })
+        end
+      end
+
+      context 'when updating an existing error summary' do
+        let!(:existing_summary) do
+          create(:job_completion_summary, extraction_id: extraction_id, error_count: 1)
+        end
+
+        it 'adds to existing error details' do
+          expect {
+            described_class.log_error(
+              extraction_id: extraction_id,
+              extraction_name: extraction_name,
+              message: message,
+              details: details
+            )
+          }.not_to change(described_class, :count)
+
+          existing_summary.reload
+          expect(existing_summary.error_count).to eq(2)
+          expect(existing_summary.error_details.size).to eq(2)
+          expect(existing_summary.last_error_at).to be > existing_summary.first_error_at
+        end
+
+        it 'preserves first_error_at timestamp' do
+          original_first_error = existing_summary.first_error_at
+          
+          described_class.log_error(
+            extraction_id: extraction_id,
+            extraction_name: extraction_name,
+            message: message,
+            details: details
+          )
+
+          existing_summary.reload
+          expect(existing_summary.first_error_at).to eq(original_first_error)
+        end
+      end
+    end
+
+    describe '.log_stop_condition_hit' do
+      let(:extraction_id) { SecureRandom.uuid }
+      let(:extraction_name) { 'Test Extraction' }
+      let(:stop_condition_name) { 'max_records' }
+      let(:stop_condition_content) { 'if records.count > 100' }
+      let(:details) { { additional: 'context' } }
+
+      context 'when creating a new stop condition summary' do
+        it 'creates a new JobCompletionSummary with stop condition details' do
+          expect {
+            described_class.log_stop_condition_hit(
+              extraction_id: extraction_id,
+              extraction_name: extraction_name,
+              stop_condition_name: stop_condition_name,
+              stop_condition_content: stop_condition_content,
+              details: details
+            )
+          }.to change(described_class, :count).by(1)
+
+          summary = described_class.last
+          expect(summary.extraction_id).to eq(extraction_id)
+          expect(summary.extraction_name).to eq(extraction_name)
+          expect(summary.error_type).to eq('stop condition')
+          expect(summary.error_count).to eq(1)
+        end
+
+        it 'stores stop condition details correctly' do
+          summary = described_class.log_stop_condition_hit(
+            extraction_id: extraction_id,
+            extraction_name: extraction_name,
+            stop_condition_name: stop_condition_name,
+            stop_condition_content: stop_condition_content,
+            details: details
+          )
+
+          error_entry = summary.error_details.first
+          expect(error_entry['message']).to eq("Stop condition '#{stop_condition_name}' was triggered")
+          expect(error_entry['details']['stop_condition_name']).to eq(stop_condition_name)
+          expect(error_entry['details']['stop_condition_content']).to eq(stop_condition_content)
+          expect(error_entry['details']['is_system_condition']).to be false
+          expect(error_entry['details']['additional']).to eq('context')
+          expect(error_entry['timestamp']).to be_present
+        end
+
+        it 'stores system stop condition details correctly' do
+          system_details = details.merge(condition_type: 'set_number_reached')
+          
+          summary = described_class.log_stop_condition_hit(
+            extraction_id: extraction_id,
+            extraction_name: extraction_name,
+            stop_condition_name: 'set_number_reached',
+            stop_condition_content: 'Set number limit reached',
+            details: system_details
+          )
+
+          error_entry = summary.error_details.first
+          expect(error_entry['message']).to eq("System stop condition 'set_number_reached' was triggered")
+          expect(error_entry['details']['stop_condition_name']).to eq('set_number_reached')
+          expect(error_entry['details']['stop_condition_content']).to eq('Set number limit reached')
+          expect(error_entry['details']['is_system_condition']).to be true
+          expect(error_entry['details']['condition_type']).to eq('set_number_reached')
+          expect(error_entry['timestamp']).to be_present
+        end
+      end
+
+      context 'when updating an existing stop condition summary' do
+        let!(:existing_summary) do
+          create(:job_completion_summary, extraction_id: extraction_id, error_type: 'stop condition', error_count: 1)
+        end
+
+        it 'adds to existing error details' do
+          expect {
+            described_class.log_stop_condition_hit(
+              extraction_id: extraction_id,
+              extraction_name: extraction_name,
+              stop_condition_name: stop_condition_name,
+              stop_condition_content: stop_condition_content,
+              details: details
+            )
+          }.not_to change(described_class, :count)
+
+          existing_summary.reload
+          expect(existing_summary.error_count).to eq(2)
+          expect(existing_summary.error_details.size).to eq(2)
+        end
+      end
+    end
+  end
+
+  describe 'instance methods' do
+
+    describe '#stop_condition?' do
+      context 'when error_type is "stop condition"' do
+        let(:summary) { build(:job_completion_summary, :stop_condition) }
+
+        it 'returns true' do
+          expect(summary.stop_condition?).to be true
+        end
+      end
+
+      context 'when error_type is not "stop condition"' do
+        let(:summary) { build(:job_completion_summary, error_type: 'error') }
+
+        it 'returns false' do
+          expect(summary.stop_condition?).to be false
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds better visibility into why SJ jobs don't finish as expected. It starts to capture all the places we might encounter a stopped pipeline, then saves any relevant error information. I've created a new JobCompletionSummary model to store this information.

This is the first step, and we will most likely be updating the logging once we get feedback from the harvesters. Additionally, we'd like to update the UI so we can more easily see which specific job has failed and why. We are waiting to complete this in the upcoming [Job Management](https://app.shortcut.com/nlnz/story/161349/job-management-design-review) story.

I have focused on harvests and extractions. There is a follow up story to work on transformations. Jobs might fail due to stop conditions (which usually are set by the harvester) or errors. There are also stop conditions that are not set by the harvester, and come from the system.

I've also created a very simple dashboard to view the completion summaries:
<img width="1502" height="643" alt="Screenshot 2025-09-22 at 9 22 46 AM" src="https://github.com/user-attachments/assets/9edb63f6-b1f2-4ea0-8d0e-a71528798f47" />
