### PR TITLE
BUG: Gracefully handle deleted jobs in the JSC table

### DIFF
--- a/app/models/job_completion_summary.rb
+++ b/app/models/job_completion_summary.rb
@@ -110,7 +110,7 @@ class JobCompletionSummary < ApplicationRecord
     extraction_job = ExtractionJob.find_by(id: job_id)
     # if job is deleted, handle safely
     return nil unless extraction_job
-    
+
     extraction_job.harvest_job&.pipeline_job&.pipeline ||
       extraction_job.extraction_definition.pipeline
   end

--- a/app/models/job_completion_summary.rb
+++ b/app/models/job_completion_summary.rb
@@ -107,7 +107,10 @@ class JobCompletionSummary < ApplicationRecord
   end
 
   def find_pipeline_from_extraction_job(job_id)
-    extraction_job = ExtractionJob.find(job_id)
+    extraction_job = ExtractionJob.find_by(id: job_id)
+    # if job is deleted, handle safely
+    return nil unless extraction_job
+    
     extraction_job.harvest_job&.pipeline_job&.pipeline ||
       extraction_job.extraction_definition.pipeline
   end

--- a/spec/models/job_completion_summary_spec.rb
+++ b/spec/models/job_completion_summary_spec.rb
@@ -126,12 +126,12 @@ RSpec.describe JobCompletionSummary, type: :model do
       expect(summary.pipeline_name).to eq('Test Pipeline')
     end
 
-    it 'raises error when job not found' do
+    it 'returns nil when job not found' do
       job = create(:extraction_job)
       summary = create(:job_completion_summary, job_id: job.id)
       summary.update!(job_id: 999999)
       
-      expect { summary.pipeline_name }.to raise_error(ActiveRecord::RecordNotFound)
+      expect(JobCompletionSummary.find_for_harvest_job(job.id)).to be_nil
     end
   end
 


### PR DESCRIPTION
If a job is deleted, and it has errors, the JCS still will reference it in the table and throw an error if the job cannot be found. This fix checks to make sure that the JCS will no longer reference jobs that have been removed.