### PR TITLE
Fix regression that put POST request body into the URL.

### DIFF
--- a/app/supplejack/extraction/base_connection.rb
+++ b/app/supplejack/extraction/base_connection.rb
@@ -28,7 +28,8 @@ module Extraction
 
     private
 
-    # The POST request does not use @connection to avoid sending the URL params as part of the URL which causes the URL to be too big and rejected by Webservers.
+    # The POST request does not use @connection to avoid sending the URL params
+    # as part of the URL which causes the URL to be too big and rejected by Webservers.
     def post_request
       connection(url, {}, headers).post(url, normalized_params.to_json, headers)
     end

--- a/app/supplejack/extraction/base_connection.rb
+++ b/app/supplejack/extraction/base_connection.rb
@@ -12,7 +12,7 @@ module Extraction
 
     def initialize(url:, params: {}, headers: {}, method: 'get')
       headers ||= {}
-      @connection = build_connection(url, params, headers)
+      @connection = connection(url, params, headers)
       @url = method == 'get' ? @connection.build_url : url
       @params = @connection.params
       @headers = @connection.headers
@@ -23,13 +23,14 @@ module Extraction
     end
 
     def post
-      Response.new(@connection.post(url, normalized_params.to_json, headers))
+      Response.new(post_request)
     end
 
     private
 
-    def build_connection(url, params, headers)
-      connection(url, params, headers)
+    # The POST request does not use @connection to avoid sending the URL params as part of the URL which causes the URL to be too big and rejected by Webservers.
+    def post_request
+      connection(url, {}, headers).post(url, normalized_params.to_json, headers)
     end
 
     # We store all values in the database as a string

--- a/spec/supplejack/extraction/connection_spec.rb
+++ b/spec/supplejack/extraction/connection_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Extraction::Connection do
 
   describe '#post' do
     before do
-      stub_request(:post, "https://google.com/hello?page=1&supplejack=jack").
+      stub_request(:post, "https://google.com/hello").
         with(
           body: "{\"supplejack\":\"jack\",\"page\":1}",
           headers: {
@@ -58,7 +58,7 @@ RSpec.describe Extraction::Connection do
         to_return(status: 200, body: "", headers: {})
     end
 
-    it 'sends the provided params in the payload' do
+    it 'sends the provided params in the payload and NOT in the URL' do
       conn = described_class.new(url: 'https://google.com/hello', params: { supplejack: 'jack', page: '1' }, headers: {}, method: 'post')
       conn.post
     end

--- a/spec/supplejack/extraction/connection_without_redirects_spec.rb
+++ b/spec/supplejack/extraction/connection_without_redirects_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Extraction::ConnectionWithoutRedirects do
 
   describe '#post' do
     before do
-      stub_request(:post, "https://google.com/hello?page=1&supplejack=jack").
+      stub_request(:post, "https://google.com/hello").
         with(
           body: "{\"supplejack\":\"jack\",\"page\":1}",
           headers: {
@@ -58,7 +58,7 @@ RSpec.describe Extraction::ConnectionWithoutRedirects do
         to_return(status: 200, body: "", headers: {})
     end
 
-    it 'sends the provided params in the payload' do
+    it 'sends the provided params in the payload and NOT the URL' do
       conn = described_class.new(url: 'https://google.com/hello', params: { supplejack: 'jack', page: '1' }, headers: {}, method: 'post')
       conn.post
     end


### PR DESCRIPTION
When the POST request is appended to the URL the URL becomes much too long and gets rejected by Puma. This means that extractions that require sending large payloads do not work. 

This was originally fixed here

https://github.com/DigitalNZ/supplejack_harvester/pull/91

and was reintroduced here

https://github.com/DigitalNZ/supplejack_harvester/pull/131

