### PR TITLE
Don't complete harvest reports while a split extraction is still pending

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ node_modules
 # from code editors
 /.vscode
 /app/frontend/jsconfig.json
+
+# LLMs
+.claude/

--- a/app/sidekiq/extraction_worker.rb
+++ b/app/sidekiq/extraction_worker.rb
@@ -62,10 +62,16 @@ class ExtractionWorker < ApplicationWorker
   end
 
   def update_harvest_report!
-    @harvest_report.extraction_completed! unless @job.extraction_definition.extract_text_from_file?
+    @harvest_report.extraction_completed! unless file_extraction_pending?
     @harvest_report.transformation_completed! if @harvest_report.transformation_workers_completed?
     @harvest_report.load_completed! if @harvest_report.load_workers_completed?
     @harvest_report.delete_completed! if @harvest_report.delete_workers_completed?
+  end
+
+  # SplitWorker and TextExtractionWorker run after this worker and mark the
+  # extraction as completed themselves once they have processed the documents.
+  def file_extraction_pending?
+    @job.extraction_definition.extract_text_from_file? || @job.extraction_definition.split?
   end
 
   def trigger_following_processes

--- a/spec/sidekiq/extraction_worker_spec.rb
+++ b/spec/sidekiq/extraction_worker_spec.rb
@@ -64,6 +64,39 @@ RSpec.describe ExtractionWorker, type: :job do
       let(:harvest_job)        { create(:harvest_job, harvest_definition:, pipeline_job:) }
       let(:harvest_report) { create(:harvest_report, pipeline_job:, harvest_job:) }
 
+      context 'when the extraction definition has split enabled' do
+        let!(:enrichment_definition) { create(:harvest_definition, kind: 'enrichment', pipeline:) }
+        let!(:enrichment_field) do
+          create(:field, name: 'title', block: "JsonPath.new('title').on(record).first",
+                         transformation_definition: enrichment_definition.transformation_definition)
+        end
+        let(:pipeline_job) do
+          create(:pipeline_job, pipeline:, destination:, harvest_definitions_to_run: [enrichment_definition.id])
+        end
+
+        before do
+          extraction_definition.update(split: true, split_selector: '//record')
+        end
+
+        it 'queues a split worker to process the extracted documents' do
+          expect do
+            subject.perform(extraction_job.id, harvest_report.id)
+          end.to change(SplitWorker.jobs, :size).by(1)
+        end
+
+        it 'does not mark the extraction as completed, as the split worker completes it after splitting' do
+          subject.perform(extraction_job.id, harvest_report.id)
+          harvest_report.reload
+          expect(harvest_report.extraction_completed?).to be false
+        end
+
+        it 'does not queue enrichments, as no records have been transformed or loaded yet' do
+          expect do
+            subject.perform(extraction_job.id, harvest_report.id)
+          end.not_to change(HarvestJob.where(harvest_definition: enrichment_definition), :count)
+        end
+      end
+
       context 'when the extraction is completed' do
         it 'updates the harvest report that the extraction is completed' do
           expect(harvest_report.extraction_completed?).to be false


### PR DESCRIPTION
**Bug:** 
Split + fresh extraction → enrichment shows all 0s / "Completed" and never runs; re-running against the existing extraction works.

**Cause:** 
`ExtractionWorker#job_end` completes the harvest report right after download, while `SplitWorker` is still queued. All counters are 0 so the report cascades to "completed" and enrichments are enqueued before any records are loaded. The 0-record enrichment job then blocks re-enqueueing when the real load finishes.

**Fix:** 
Skip `extraction_completed!` when a split is pending . `SplitWorker` already marks it completed after splitting (same guard 1791145a added for text extraction).
