### PR TITLE
Enrich every record when skip previously enriched is enabled

### DIFF
--- a/app/supplejack/extraction/sj_api_enrichment_iterator.rb
+++ b/app/supplejack/extraction/sj_api_enrichment_iterator.rb
@@ -12,15 +12,20 @@ module Extraction
       @max_page = find_max_page(@first_api_document) if @first_api_document.body.present?
     end
 
+    # Enriching a record removes it from the 'skip previously enriched'
+    # filtered results, shifting every record behind it forward a page.
+    # Pages are processed from last to first so that the shrinking result
+    # set never shifts records into a page that has already been processed.
     def each
-      yield(@first_api_document, @page)
-      @page += 1
+      if @max_page.present?
+        @max_page.downto(@page + 1).each do |page|
+          break if @extraction_job.reload.cancelled?
 
-      (@page..@max_page).each do |page|
-        break if @extraction_job.reload.cancelled?
-
-        yield(get_api_document(page), page)
+          yield(get_api_document(page), page)
+        end
       end
+
+      yield(@first_api_document, @page)
     end
 
     def find_max_page(record_extraction)

--- a/spec/supplejack/extraction/sj_api_enrichment_iterator_spec.rb
+++ b/spec/supplejack/extraction/sj_api_enrichment_iterator_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Extraction::SjApiEnrichmentIterator do
+  let(:destination)           { create(:destination) }
+  let(:pipeline)              { create(:pipeline) }
+  let(:pipeline_job)          { create(:pipeline_job, pipeline:, destination:, skip_previously_enriched: true) }
+  let(:harvest_definition)    { create(:harvest_definition, pipeline:) }
+  let(:harvest_job)           { create(:harvest_job, harvest_definition:, pipeline_job:) }
+  let(:extraction_definition) { create(:extraction_definition, :enrichment, destination:, page: 1) }
+  let!(:request)              { create(:request, extraction_definition:) }
+  let(:extraction_job)        { create(:extraction_job, extraction_definition:, harvest_job:) }
+
+  describe '#each' do
+    context 'when skip previously enriched removes records from the result set as they are enriched' do
+      let(:all_record_ids)        { (1..100).map(&:to_s) }
+      let(:unenriched_record_ids) { all_record_ids.dup }
+
+      before do
+        # The API pages over "records without this enrichment fragment".
+        # Records disappear from that result set once their fragment lands,
+        # so page N is computed against whatever is unenriched at fetch time.
+        stub_request(:get, "#{destination.url}/harvester/records")
+          .with(query: hash_including('api_key' => 'testkey'))
+          .to_return do |request|
+            query = Rack::Utils.parse_nested_query(URI(request.uri.to_s).query)
+            page = query.dig('search_options', 'page').to_i
+            page_of_records = unenriched_record_ids.each_slice(20).to_a[page - 1] || []
+            total_pages = (unenriched_record_ids.length / 20.0).ceil
+
+            {
+              status: 200,
+              headers: { 'Content-Type' => 'application/json' },
+              body: {
+                records: page_of_records.map { |id| { 'id' => id } },
+                meta: { page:, total_pages: }
+              }.to_json
+            }
+          end
+      end
+
+      it 'yields every record from the initial result set exactly once' do
+        yielded_record_ids = []
+
+        described_class.new(extraction_job).each do |api_document, _page|
+          record_ids = JSON.parse(api_document.body)['records'].map { |record| record['id'] }
+          yielded_record_ids.concat(record_ids)
+
+          # Simulate the enrichment fragments landing in the API
+          # before the next page is fetched.
+          unenriched_record_ids.reject! { |id| record_ids.include?(id) }
+        end
+
+        expect(yielded_record_ids).to match_array(all_record_ids)
+      end
+    end
+  end
+end


### PR DESCRIPTION
**Problem:**
- "Skip Previously Enriched" enrichments miss large blocks of records. A 100-record harvest only enriches ~60.
- Re-runs miss again: only about half of the remaining records get picked up each time.
- Small harvests (≤ 20 records) work fine.

**Root cause:**
- With skip enabled, the record query excludes records that already have the enrichment fragment (exclude_source_id).
- SjApiEnrichmentIterator pages through that query ascending, re-issuing it per page while the enrichment is creating those very fragments.
- Every enriched record drops out of the filtered results, shifting the records behind it into page positions already visited. Those records are never fetched.
- With the API's fixed page size of 20: pages 1–20 enrich, "page 2" now returns originals 41–60 (21–40 slid into page 1's spot), etc. → exactly 60/100.

**Fix:**
- Process pages last-to-first. Enriched records always sit behind the pages still to be fetched, so nothing shifts under the iterator.
- Correct regardless of when fragments land. Immune to the timing race.
- Sample jobs and cancellation behaviour unchanged.

