### PR TITLE
Pre-processing pipeline bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,4 @@ node_modules
 # LLMs
 .claude/
 .playwright-mcp/
+docs/

--- a/app/frontend/js/apps/ExtractionApp/components/NavTabs.jsx
+++ b/app/frontend/js/apps/ExtractionApp/components/NavTabs.jsx
@@ -7,7 +7,6 @@ import { selectRequestIds } from "~/js/features/ExtractionApp/RequestsSlice";
 import { selectAllParameters } from "~/js/features/ExtractionApp/ParametersSlice";
 import { selectAppDetails } from "~/js/features/TransformationApp/AppDetailsSlice";
 import { selectAllSharedDefinitions } from "~/js/features/SharedDefinitionsSlice";
-import { selectHarvestDefinition } from "/js/features/ExtractionApp/AppDetailsSlice";
 
 import { toggleDisplayParameters } from "~/js/features/ExtractionApp/UiParametersSlice";
 
@@ -20,11 +19,15 @@ import {
 
 const NavTabs = () => {
   const dispatch = useDispatch();
-  const harvestDefinition = useSelector(selectHarvestDefinition);
   const appDetails = useSelector(selectAppDetails);
   const uiAppDetails = useSelector(selectUiAppDetails);
   const requestIds = useSelector(selectRequestIds);
-  const initialRequestIndex = harvestDefinition.kind == "harvest" ? 0 : 1;
+  // The configured request lives on the FIRST request for a harvest-kind
+  // extraction definition (including pre-processing blocks, which are stored
+  // with kind: 'harvest') and on the LAST request for an enrichment - this
+  // must mirror ExtractionDefinition#configured_request.
+  const initialRequestIndex =
+    appDetails.extractionDefinition.kind == "harvest" ? 0 : 1;
   const initialRequestId = requestIds[initialRequestIndex];
   const mainRequestId = requestIds[1];
   const sharedDefinitions = useSelector(selectAllSharedDefinitions);

--- a/app/views/extraction_definitions/show.html.erb
+++ b/app/views/extraction_definitions/show.html.erb
@@ -23,18 +23,22 @@
 
 <div id="js-extraction-app" data-props="<%= @props %>"></div>
 
-<% if @harvest_definition.harvest? %>
-  <%= render 'create_edit_harvest_modal',
-             id: 'update-extraction-definition-modal',
-             model: @extraction_definition,
-             modal_heading: 'Edit extraction definition',
-             modal_subheading: 'Define the settings for your extraction definition',
-             confirmation_button_text: 'Update extraction definition' %>
-<% else %>
+<%# A pre-processing block's extraction definition is created with kind: 'harvest'
+    (see app/views/pipelines/_preprocess_definition.html.erb), so it must be edited
+    with the harvest modal too - the enrichment modal would silently rewrite its
+    kind to 'enrichment' via a hidden field. %>
+<% if @harvest_definition.enrichment? %>
   <%= render 'create_edit_enrichment_modal',
              id: 'update-extraction-definition-modal',
              model: @extraction_definition,
              enrichment_definition: @harvest_definition,
+             modal_heading: 'Edit extraction definition',
+             modal_subheading: 'Define the settings for your extraction definition',
+             confirmation_button_text: 'Update extraction definition' %>
+<% else %>
+  <%= render 'create_edit_harvest_modal',
+             id: 'update-extraction-definition-modal',
+             model: @extraction_definition,
              modal_heading: 'Edit extraction definition',
              modal_subheading: 'Define the settings for your extraction definition',
              confirmation_button_text: 'Update extraction definition' %>

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
       "app/frontend"
     ],
     "moduleNameMapper": {
-      "~/(.*)": "<rootDir>/app/frontend/$1"
+      "~/(.*)": "<rootDir>/app/frontend/$1",
+      "^/js/(.*)": "<rootDir>/app/frontend/js/$1"
     },
     "testEnvironment": "jsdom",
     "setupFilesAfterEnv": [

--- a/spec/javascript/ExtractionApp/components/NavTabs.spec.js
+++ b/spec/javascript/ExtractionApp/components/NavTabs.spec.js
@@ -1,0 +1,148 @@
+import React from "react";
+import { fireEvent, screen } from "@testing-library/react";
+import { render } from "@testing-library/react";
+import { configureStore, combineReducers } from "@reduxjs/toolkit";
+import { Provider } from "react-redux";
+
+import NavTabs from "~/js/apps/ExtractionApp/components/NavTabs";
+
+// entities
+import requests from "~/js/features/ExtractionApp/RequestsSlice";
+import parameters from "~/js/features/ExtractionApp/ParametersSlice";
+import appDetails from "~/js/features/ExtractionApp/AppDetailsSlice";
+import stopConditions from "~/js/features/ExtractionApp/StopConditionsSlice";
+import sharedDefinitions from "~/js/features/SharedDefinitionsSlice";
+
+// ui
+import uiParameters from "~/js/features/ExtractionApp/UiParametersSlice";
+import uiRequests from "~/js/features/ExtractionApp/UiRequestsSlice";
+import uiAppDetails from "~/js/features/ExtractionApp/UiAppDetailsSlice";
+import uiStopConditions from "~/js/features/ExtractionApp/UiStopConditionsSlice";
+
+// config
+import config from "~/js/features/ConfigSlice";
+
+const emptyEntities = { ids: [], entities: {} };
+
+function renderNavTabs({ harvestDefinitionKind, extractionDefinition, activeRequest }) {
+  const store = configureStore({
+    reducer: combineReducers({
+      entities: combineReducers({
+        requests,
+        parameters,
+        appDetails,
+        sharedDefinitions,
+        stopConditions,
+      }),
+      ui: combineReducers({
+        parameters: uiParameters,
+        requests: uiRequests,
+        appDetails: uiAppDetails,
+        stopConditions: uiStopConditions,
+      }),
+      config,
+    }),
+    preloadedState: {
+      entities: {
+        requests: {
+          ids: [10, 11],
+          entities: { 10: { id: 10 }, 11: { id: 11 } },
+        },
+        parameters: emptyEntities,
+        appDetails: {
+          harvestDefinition: { kind: harvestDefinitionKind },
+          extractionDefinition,
+        },
+        sharedDefinitions: emptyEntities,
+        stopConditions: emptyEntities,
+      },
+      ui: {
+        parameters: emptyEntities,
+        requests: emptyEntities,
+        appDetails: {
+          activeRequest,
+          sharedDefinitionsTabActive: false,
+          stopConditionsTabActive: false,
+        },
+        stopConditions: emptyEntities,
+      },
+      config: {},
+    },
+  });
+
+  return render(
+    <Provider store={store}>
+      <NavTabs />
+    </Provider>
+  );
+}
+
+describe("<NavTabs />", () => {
+  beforeEach(() => {
+    const portalTarget = document.createElement("div");
+    portalTarget.setAttribute("id", "react-nav-tabs");
+    document.body.appendChild(portalTarget);
+  });
+
+  afterEach(() => {
+    document.getElementById("react-nav-tabs").remove();
+  });
+
+  describe("when the extraction definition belongs to a pre-processing block", () => {
+    // A pre-processing block's extraction definition is stored with
+    // kind: 'harvest', so its configured request is the FIRST request -
+    // the same as a harvest.
+    const preprocessProps = {
+      harvestDefinitionKind: "preprocess",
+      extractionDefinition: { id: 1, kind: "harvest", paginated: true },
+      activeRequest: 10,
+    };
+
+    it("marks the first request tab as active on load", () => {
+      renderNavTabs(preprocessProps);
+
+      expect(screen.getByText("First Request").classList.contains("active")).toBe(true);
+      expect(screen.getByText("Following Requests").classList.contains("active")).toBe(false);
+    });
+
+    it("only activates one tab at a time when clicking between them", () => {
+      renderNavTabs(preprocessProps);
+
+      fireEvent.click(screen.getByText("Following Requests"));
+
+      expect(screen.getByText("Following Requests").classList.contains("active")).toBe(true);
+      expect(screen.getByText("First Request").classList.contains("active")).toBe(false);
+
+      fireEvent.click(screen.getByText("First Request"));
+
+      expect(screen.getByText("First Request").classList.contains("active")).toBe(true);
+      expect(screen.getByText("Following Requests").classList.contains("active")).toBe(false);
+    });
+  });
+
+  describe("when the extraction definition belongs to a harvest", () => {
+    it("marks the first request tab as active on load", () => {
+      renderNavTabs({
+        harvestDefinitionKind: "harvest",
+        extractionDefinition: { id: 1, kind: "harvest", paginated: true },
+        activeRequest: 10,
+      });
+
+      expect(screen.getByText("First Request").classList.contains("active")).toBe(true);
+      expect(screen.getByText("Following Requests").classList.contains("active")).toBe(false);
+    });
+  });
+
+  describe("when the extraction definition belongs to an enrichment", () => {
+    // An enrichment's configured request is the LAST request.
+    it("marks the request tab as active on load", () => {
+      renderNavTabs({
+        harvestDefinitionKind: "enrichment",
+        extractionDefinition: { id: 1, kind: "enrichment", paginated: false },
+        activeRequest: 11,
+      });
+
+      expect(screen.getByText("Request").classList.contains("active")).toBe(true);
+    });
+  });
+});

--- a/spec/requests/extraction_definitions_spec.rb
+++ b/spec/requests/extraction_definitions_spec.rb
@@ -12,6 +12,58 @@ RSpec.describe 'ExtractionDefinitions' do
     sign_in user
   end
 
+  describe '#show' do
+    context 'when the extraction definition belongs to a harvest' do
+      let!(:requests) { create_list(:request, 2, extraction_definition:) }
+
+      it 'renders the harvest settings modal' do
+        get pipeline_harvest_definition_extraction_definition_path(pipeline, harvest_definition,
+                                                                   extraction_definition)
+
+        expect(response.body).to include 'Paginated'
+        expect(response.body).not_to include 'Target Source ID'
+      end
+    end
+
+    context 'when the extraction definition belongs to a pre-processing block' do
+      let(:preprocess_extraction_definition) { create(:extraction_definition, pipeline:) }
+      let(:preprocess_definition) do
+        create(:harvest_definition, kind: :preprocess, pipeline:,
+                                    extraction_definition: preprocess_extraction_definition, source_id: 'pre-0')
+      end
+
+      let!(:requests) { create_list(:request, 2, extraction_definition: preprocess_extraction_definition) }
+
+      it 'renders the harvest settings modal' do
+        get pipeline_harvest_definition_extraction_definition_path(pipeline, preprocess_definition,
+                                                                   preprocess_extraction_definition)
+
+        expect(response.body).to include 'Paginated'
+        expect(response.body).not_to include 'Target Source ID'
+      end
+    end
+
+    context 'when the extraction definition belongs to an enrichment' do
+      let(:enrichment_extraction_definition) do
+        create(:extraction_definition, :enrichment, pipeline:, destination: create(:destination))
+      end
+      let(:enrichment_definition) do
+        create(:harvest_definition, kind: :enrichment, pipeline:,
+                                    extraction_definition: enrichment_extraction_definition)
+      end
+
+      let!(:requests) { create_list(:request, 2, extraction_definition: enrichment_extraction_definition) }
+
+      it 'renders the enrichment settings modal' do
+        get pipeline_harvest_definition_extraction_definition_path(pipeline, enrichment_definition,
+                                                                   enrichment_extraction_definition)
+
+        expect(response.body).to include 'Target Source ID'
+        expect(response.body).not_to include 'Paginated'
+      end
+    end
+  end
+
   describe '#create' do
     context 'with valid parameters' do
       let(:extraction_definition2) { build(:extraction_definition, pipeline:) }


### PR DESCRIPTION
Fixes two bugs with extraction definitions in pre-processing blocks

A pre-processing block's extraction definition is deliberately stored with kind: 'harvest', but two places branched on the block's kind (preprocess) instead of the definition's, so they wrongly treated it as an enrichment.

- Settings modal showed enrichment settings after save. The extraction definition show page picked the modal via `@harvest_definition.harvest?`. Preprocess blocks now get the same harvest modal (with pagination) they were created with. This also prevented a nastier side effect: saving from the wrong modal silently rewrote the definition's kind to enrichment via a hidden field.
- "First Request" / "Following Requests" tabs selected both at once. `NavTabs.jsx` pointed both tabs at the same request for preprocess blocks. The tab index now keys off the extraction definition's own kind, mirroring `ExtractionDefinition#configured_request`.