### PR TITLE
Pre-processing extraction preview

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -49,6 +49,7 @@ Metrics/AbcSize:
 
 Metrics/ClassLength:
   Exclude:
+    - "app/controllers/requests_controller.rb"
     - "app/models/job_completion_summary.rb"
     - "app/supplejack/extraction/execution.rb"
     - "app/supplejack/job_completion_summary_logger.rb"

--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -99,11 +99,11 @@ class RequestsController < ApplicationController
   end
 
   def build_preprocess_preview(run, runs)
-    documents, records, api_record = preprocess_input(run)
+    documents, records, input_record = preprocess_input(run)
 
     {
-      input: api_record.to_hash,
-      response: preprocess_response(api_record),
+      input: input_record.to_hash,
+      response: preprocess_response(input_record),
       total_pages: documents.total_pages,
       total_records: records.count,
       runs: runs.map { |job| { id: job.id, label: run_label(job) } },
@@ -114,9 +114,9 @@ class RequestsController < ApplicationController
   def preprocess_input(run)
     documents = PreProcess::Output.new(run.id, preceding_position).documents
     records = preprocess_page_records(documents)
-    api_record = Extraction::ApiRecord.new(records[record_param.to_i - 1])
+    input_record = Extraction::ApiRecord.new(records[record_param.to_i - 1])
 
-    [documents, records, api_record]
+    [documents, records, input_record]
   end
 
   def empty_preprocess_preview
@@ -131,6 +131,8 @@ class RequestsController < ApplicationController
   end
 
   def chosen_run(runs)
+    # Fall back to the most recent run when the requested pipeline_job_id isn't among this
+    # position's runs (e.g. stale client state). Safe: runs is already pipeline-scoped.
     runs.find { |job| job.id == params[:pipeline_job_id].to_i } || runs.first
   end
 
@@ -143,10 +145,10 @@ class RequestsController < ApplicationController
     []
   end
 
-  def preprocess_response(api_record)
-    return {} if api_record.body.blank?
+  def preprocess_response(input_record)
+    return {} if input_record.body.blank?
 
-    document = Extraction::EnrichmentExtraction.new(@request, api_record).extract
+    document = Extraction::EnrichmentExtraction.new(@request, input_record).extract
     document.respond_to?(:to_hash) ? document.to_hash : {}
   end
 

--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -8,6 +8,7 @@ class RequestsController < ApplicationController
   def show
     @request = Request.find(params[:id])
 
+    return preprocess_request if preprocess_consumer?
     return harvest_request if @request.extraction_definition.harvest?
 
     enrichment_request
@@ -80,6 +81,89 @@ class RequestsController < ApplicationController
 
   def second_enrichment_request_response
     @request.to_h.merge(preview: Extraction::EnrichmentExtraction.new(@request, api_record).extract)
+  end
+
+  def preprocess_consumer?
+    @request.extraction_definition.harvest? && harvest_definition.position.to_i.positive?
+  end
+
+  def preprocess_request
+    render json: @request.to_h.merge(preview: preprocess_preview)
+  end
+
+  def preprocess_preview
+    runs = preprocess_runs
+    return empty_preprocess_preview if runs.empty?
+
+    build_preprocess_preview(chosen_run(runs), runs)
+  end
+
+  def build_preprocess_preview(run, runs)
+    documents, records, api_record = preprocess_input(run)
+
+    {
+      input: api_record.to_hash,
+      response: preprocess_response(api_record),
+      total_pages: documents.total_pages,
+      total_records: records.count,
+      runs: runs.map { |job| { id: job.id, label: run_label(job) } },
+      current_run_id: run.id
+    }
+  end
+
+  def preprocess_input(run)
+    documents = PreProcess::Output.new(run.id, preceding_position).documents
+    records = preprocess_page_records(documents)
+    api_record = Extraction::ApiRecord.new(records[record_param.to_i - 1])
+
+    [documents, records, api_record]
+  end
+
+  def empty_preprocess_preview
+    { input: nil, response: nil, total_pages: 0, total_records: 0, runs: [], current_run_id: nil }
+  end
+
+  def preprocess_runs
+    pipeline.pipeline_jobs
+            .where(id: PreProcess::Output.pipeline_job_ids_with_output(preceding_position))
+            .order(created_at: :desc)
+            .to_a
+  end
+
+  def chosen_run(runs)
+    runs.find { |job| job.id == params[:pipeline_job_id].to_i } || runs.first
+  end
+
+  def preprocess_page_records(documents)
+    document = documents[page_param]
+    return [] unless document.is_a?(Extraction::Document)
+
+    JSON.parse(document.body)['records'] || []
+  rescue JSON::ParserError
+    []
+  end
+
+  def preprocess_response(api_record)
+    return {} if api_record.body.blank?
+
+    document = Extraction::EnrichmentExtraction.new(@request, api_record).extract
+    document.respond_to?(:to_hash) ? document.to_hash : {}
+  end
+
+  def preceding_position
+    harvest_definition.position.to_i - 1
+  end
+
+  def run_label(job)
+    "Job ##{job.id} - #{job.created_at.strftime('%-d %b %Y, %H:%M')}"
+  end
+
+  def pipeline
+    @pipeline ||= Pipeline.find(params[:pipeline_id])
+  end
+
+  def harvest_definition
+    @harvest_definition ||= HarvestDefinition.find(params[:harvest_definition_id])
   end
 
   def request_params

--- a/app/frontend/js/apps/ExtractionApp/components/HeaderActions.jsx
+++ b/app/frontend/js/apps/ExtractionApp/components/HeaderActions.jsx
@@ -9,6 +9,7 @@ import {
 } from "~/js/features/ExtractionApp/RequestsSlice";
 import PreviewModal from "~/js/apps/ExtractionApp/components/PreviewModal";
 import EnrichmentPreviewModal from "~/js/apps/ExtractionApp/components/EnrichmentPreviewModal";
+import PreprocessPreviewModal from "~/js/apps/ExtractionApp/components/PreprocessPreviewModal";
 import RunSample from "~/js/apps/ExtractionApp/components/RunSample";
 
 const HeaderActions = () => {
@@ -19,12 +20,20 @@ const HeaderActions = () => {
   const initialRequestId = requestIds[0];
   const mainRequestId = requestIds[1];
 
+  const isPreprocessConsumer =
+    appDetails.extractionDefinition.kind == "harvest" &&
+    appDetails.harvestDefinition.position > 0;
+
   const [showModal, setShowModal] = useState(false);
   const handleClose = () => setShowModal(false);
   const handleShow = () => setShowModal(true);
 
   const handlePreviewClick = async () => {
     handleShow();
+
+    if (isPreprocessConsumer) {
+      return;
+    }
 
     dispatch(setLoading(initialRequestId));
     dispatch(setLoading(mainRequestId));
@@ -69,14 +78,23 @@ const HeaderActions = () => {
 
       {appDetails.extractionDefinition.split && <RunSample />}
 
-      {appDetails.extractionDefinition.kind == "harvest" && (
-        <PreviewModal
+      {isPreprocessConsumer && (
+        <PreprocessPreviewModal
           showModal={showModal}
           handleClose={handleClose}
-          initialRequestId={initialRequestId}
-          mainRequestId={mainRequestId}
+          requestId={initialRequestId}
         />
       )}
+
+      {!isPreprocessConsumer &&
+        appDetails.extractionDefinition.kind == "harvest" && (
+          <PreviewModal
+            showModal={showModal}
+            handleClose={handleClose}
+            initialRequestId={initialRequestId}
+            mainRequestId={mainRequestId}
+          />
+        )}
 
       {appDetails.extractionDefinition.kind == "enrichment" && (
         <EnrichmentPreviewModal

--- a/app/frontend/js/apps/ExtractionApp/components/PreprocessPreviewModal.jsx
+++ b/app/frontend/js/apps/ExtractionApp/components/PreprocessPreviewModal.jsx
@@ -90,8 +90,9 @@ const PreprocessPreviewModal = ({ showModal, handleClose, requestId }) => {
         <Modal.Title>Pre-processed data extraction preview</Modal.Title>
 
         <div className="float-end d-flex align-items-center">
-          <label className="me-2 mb-0">Preview Data:</label>
+          <label className="me-2 mb-0" htmlFor="preprocess-preview-run">Preview Data:</label>
           <select
+            id="preprocess-preview-run"
             className="form-select me-2"
             style={{ width: "auto" }}
             value={selectedRunId}
@@ -126,7 +127,7 @@ const PreprocessPreviewModal = ({ showModal, handleClose, requestId }) => {
         )}
 
         {!loading && runs.length == 0 && (
-          <p className="text-danger">
+          <p className="text-muted">
             No pre-processed data yet — run the pipeline first.
           </p>
         )}

--- a/app/frontend/js/apps/ExtractionApp/components/PreprocessPreviewModal.jsx
+++ b/app/frontend/js/apps/ExtractionApp/components/PreprocessPreviewModal.jsx
@@ -1,0 +1,194 @@
+import React, { useState, useEffect } from "react";
+import { createPortal } from "react-dom";
+import { useSelector, useDispatch } from "react-redux";
+import { selectAppDetails } from "~/js/features/ExtractionApp/AppDetailsSlice";
+
+import Modal from "react-bootstrap/Modal";
+import PreviewPanel from "~/js/apps/ExtractionApp/components/PreviewPanel";
+
+import { previewRequest, selectRequestById } from "~/js/features/ExtractionApp/RequestsSlice";
+import {
+  setLoading,
+  selectUiRequestById,
+} from "~/js/features/ExtractionApp/UiRequestsSlice";
+
+const PreprocessPreviewModal = ({ showModal, handleClose, requestId }) => {
+  const dispatch = useDispatch();
+  const appDetails = useSelector(selectAppDetails);
+
+  const [currentPage, setCurrentPage] = useState(1);
+  const [currentRecord, setCurrentRecord] = useState(1);
+  const [currentRunId, setCurrentRunId] = useState(null);
+
+  const { loading } = useSelector((state) => selectUiRequestById(state, requestId));
+  const { preview, format } = useSelector((state) =>
+    selectRequestById(state, requestId)
+  );
+
+  const runs = preview?.runs || [];
+  const totalPages = preview?.total_pages || 0;
+  const totalRecords = preview?.total_records || 0;
+  const selectedRunId = currentRunId ?? preview?.current_run_id ?? "";
+
+  useEffect(() => {
+    if (!showModal) return;
+
+    dispatch(setLoading(requestId));
+    dispatch(
+      previewRequest({
+        pipelineId: appDetails.pipeline.id,
+        harvestDefinitionId: appDetails.harvestDefinition.id,
+        extractionDefinitionId: appDetails.extractionDefinition.id,
+        id: requestId,
+        page: currentPage,
+        record: currentRecord,
+        pipelineJobId: currentRunId,
+      })
+    );
+  }, [showModal, currentPage, currentRecord, currentRunId]);
+
+  const handleNextRecordClick = () => {
+    if (currentRecord < totalRecords) {
+      setCurrentRecord(currentRecord + 1);
+    } else {
+      setCurrentPage(currentPage + 1);
+      setCurrentRecord(1);
+    }
+  };
+
+  const handlePreviousRecordClick = () => {
+    if (currentRecord > 1) {
+      setCurrentRecord(currentRecord - 1);
+    } else {
+      setCurrentPage(currentPage - 1);
+      setCurrentRecord(totalRecords);
+    }
+  };
+
+  const handleRunChange = (event) => {
+    setCurrentRunId(Number(event.target.value));
+    setCurrentPage(1);
+    setCurrentRecord(1);
+  };
+
+  const canNotClickPreviousRecord = () =>
+    loading || (currentPage == 1 && currentRecord == 1);
+
+  const canNotClickNextRecord = () =>
+    loading ||
+    totalRecords == 0 ||
+    (currentPage == totalPages && currentRecord == totalRecords);
+
+  return createPortal(
+    <Modal
+      size="lg"
+      show={showModal}
+      onHide={handleClose}
+      className="modal--full-width"
+    >
+      <Modal.Header>
+        <Modal.Title>Pre-processed data extraction preview</Modal.Title>
+
+        <div className="float-end d-flex align-items-center">
+          <label className="me-2 mb-0">Preview Data:</label>
+          <select
+            className="form-select me-2"
+            style={{ width: "auto" }}
+            value={selectedRunId}
+            onChange={handleRunChange}
+            disabled={loading || runs.length == 0}
+          >
+            {runs.map((run) => (
+              <option key={run.id} value={run.id}>
+                {run.label}
+              </option>
+            ))}
+          </select>
+
+          <button
+            className="btn btn-outline-primary"
+            onClick={() => {
+              handleClose();
+            }}
+          >
+            <i className="bi bi-pencil-square me-1" aria-hidden="true"></i>
+            Return to edit extraction
+          </button>
+        </div>
+      </Modal.Header>
+      <Modal.Body>
+        {loading && runs.length == 0 && (
+          <div className="d-flex justify-content-center">
+            <div className="spinner-border text-primary" role="status">
+              <span className="visually-hidden">Loading...</span>
+            </div>
+          </div>
+        )}
+
+        {!loading && runs.length == 0 && (
+          <p className="text-danger">
+            No pre-processed data yet — run the pipeline first.
+          </p>
+        )}
+
+        {runs.length > 0 && (
+          <>
+            <h5 className="float-start">
+              Record {currentRecord} / {totalRecords} | Page {currentPage} /{" "}
+              {totalPages}
+            </h5>
+
+            <div className="float-end">
+              <button
+                className="btn btn-outline-primary me-2"
+                disabled={canNotClickPreviousRecord()}
+                onClick={() => {
+                  handlePreviousRecordClick();
+                }}
+              >
+                <i className="bi bi-arrow-left-short me-1" aria-hidden="true"></i>
+                Previous record
+              </button>
+
+              <button
+                className="btn btn-outline-primary"
+                disabled={canNotClickNextRecord()}
+                onClick={() => {
+                  handleNextRecordClick();
+                }}
+              >
+                Next record
+                <i className="bi bi-arrow-right-short me-1" aria-hidden="true"></i>
+              </button>
+            </div>
+
+            <div className="clearfix"></div>
+
+            <div className="row">
+              <div className="col-6">
+                <PreviewPanel
+                  preview={preview?.input}
+                  format="JSON"
+                  loading={loading}
+                  view="apiRecord"
+                />
+              </div>
+
+              <div className="col-6">
+                <PreviewPanel
+                  preview={preview?.response}
+                  format={format}
+                  loading={loading}
+                  view="accordion"
+                />
+              </div>
+            </div>
+          </>
+        )}
+      </Modal.Body>
+    </Modal>,
+    document.getElementById("react-modals")
+  );
+};
+
+export default PreprocessPreviewModal;

--- a/app/frontend/js/apps/ExtractionApp/components/Preview.jsx
+++ b/app/frontend/js/apps/ExtractionApp/components/Preview.jsx
@@ -1,158 +1,18 @@
 import React from "react";
 
 import { useSelector } from "react-redux";
-import { map } from "lodash";
 
 import { selectUiRequestById } from "~/js/features/ExtractionApp/UiRequestsSlice";
 import { selectRequestById } from "~/js/features/ExtractionApp/RequestsSlice";
 
-import CodeEditor from "~/js/components/CodeEditor";
+import PreviewPanel from "~/js/apps/ExtractionApp/components/PreviewPanel";
 
 const Preview = ({ id, view = "accordion" }) => {
   const { loading } = useSelector((state) => selectUiRequestById(state, id));
-  const { preview, format } = useSelector((state) =>
-    selectRequestById(state, id)
-  );
-
-  const formattedPayload = () => {
-    return (
-      <>
-        <br />
-        <br />
-        <pre>{JSON.stringify(preview.params, null, 2)}</pre>
-      </>
-    );
-  };
-
-  const accordionView = () => {
-    return (
-      <>
-        <div className="accordion mt-4">
-          <div className="accordion-item">
-            <h2 className="accordion-header">
-              <button
-                className="accordion-button"
-                type="button"
-                data-bs-toggle="collapse"
-                data-bs-target="#request"
-                aria-expanded="true"
-                aria-controls="request"
-              >
-                Request ({preview.method})
-              </button>
-            </h2>
-            <div id="request" className="accordion-collapse collapse show">
-              <div className="accordion-body">
-                {preview.method == "GET" && (
-                  <a href={preview.url} target="_blank">
-                    {preview.url}
-                  </a>
-                )}
-                {preview.method == "POST" && preview.url}
-                {preview.method == "POST" && formattedPayload()}
-              </div>
-            </div>
-          </div>
-
-          <div className="accordion-item">
-            <h2 className="accordion-header">
-              <button
-                className="accordion-button"
-                type="button"
-                data-bs-toggle="collapse"
-                data-bs-target="#headers"
-                aria-expanded="true"
-                aria-controls="response"
-              >
-                Request Headers
-              </button>
-            </h2>
-            <div id="headers" className="accordion-collapse collapse">
-              <div className="accordion-body">
-                {map(preview.request_headers, (value, key) => {
-                  return (
-                    <p key={key}>
-                      {key}: {value}
-                    </p>
-                  );
-                })}
-              </div>
-            </div>
-          </div>
-
-          <div className="accordion-item">
-            <h2 className="accordion-header">
-              <button
-                className="accordion-button"
-                type="button"
-                data-bs-toggle="collapse"
-                data-bs-target="#response"
-                aria-expanded="true"
-                aria-controls="response"
-              >
-                Response Body
-              </button>
-            </h2>
-            <div id="response" className="accordion-collapse collapse show">
-              <div className="accordion-body">
-                <CodeEditor initContent={preview.body} format={format} />
-              </div>
-            </div>
-          </div>
-
-          <div className="accordion-item">
-            <h2 className="accordion-header">
-              <button
-                className="accordion-button"
-                type="button"
-                data-bs-toggle="collapse"
-                data-bs-target="#response-headers"
-                aria-expanded="true"
-                aria-controls="response-headers"
-              >
-                Response Headers
-              </button>
-            </h2>
-            <div id="response-headers" className="accordion-collapse collapse">
-              <div className="accordion-body">
-                {map(preview.response_headers, (value, key) => {
-                  return (
-                    <p key={key}>
-                      {key}: {value}
-                    </p>
-                  );
-                })}
-              </div>
-            </div>
-          </div>
-        </div>
-      </>
-    );
-  };
-
-  const apiRecordView = () => {
-    return (
-      <>
-        <div className="card p-4 mt-4">
-          <strong className="mb-4">API Response</strong>
-          <CodeEditor initContent={preview.body} format="JSON" />
-        </div>
-      </>
-    );
-  };
+  const { preview, format } = useSelector((state) => selectRequestById(state, id));
 
   return (
-    <>
-      {loading && (
-        <div className="d-flex justify-content-center">
-          <div className="spinner-border text-primary" role="status">
-            <span className="visually-hidden">Loading...</span>
-          </div>
-        </div>
-      )}
-      {!loading && view == "accordion" && accordionView()}
-      {!loading && view == "apiRecord" && apiRecordView()}
-    </>
+    <PreviewPanel preview={preview} format={format} loading={loading} view={view} />
   );
 };
 

--- a/app/frontend/js/apps/ExtractionApp/components/PreviewPanel.jsx
+++ b/app/frontend/js/apps/ExtractionApp/components/PreviewPanel.jsx
@@ -1,0 +1,149 @@
+import React from "react";
+import { map } from "lodash";
+
+import CodeEditor from "~/js/components/CodeEditor";
+
+const PreviewPanel = ({ preview, format, loading = false, view = "accordion" }) => {
+  const formattedPayload = () => {
+    return (
+      <>
+        <br />
+        <br />
+        <pre>{JSON.stringify(preview.params, null, 2)}</pre>
+      </>
+    );
+  };
+
+  const accordionView = () => {
+    return (
+      <>
+        <div className="accordion mt-4">
+          <div className="accordion-item">
+            <h2 className="accordion-header">
+              <button
+                className="accordion-button"
+                type="button"
+                data-bs-toggle="collapse"
+                data-bs-target="#request"
+                aria-expanded="true"
+                aria-controls="request"
+              >
+                Request ({preview.method})
+              </button>
+            </h2>
+            <div id="request" className="accordion-collapse collapse show">
+              <div className="accordion-body">
+                {preview.method == "GET" && (
+                  <a href={preview.url} target="_blank">
+                    {preview.url}
+                  </a>
+                )}
+                {preview.method == "POST" && preview.url}
+                {preview.method == "POST" && formattedPayload()}
+              </div>
+            </div>
+          </div>
+
+          <div className="accordion-item">
+            <h2 className="accordion-header">
+              <button
+                className="accordion-button"
+                type="button"
+                data-bs-toggle="collapse"
+                data-bs-target="#headers"
+                aria-expanded="true"
+                aria-controls="response"
+              >
+                Request Headers
+              </button>
+            </h2>
+            <div id="headers" className="accordion-collapse collapse">
+              <div className="accordion-body">
+                {map(preview.request_headers, (value, key) => {
+                  return (
+                    <p key={key}>
+                      {key}: {value}
+                    </p>
+                  );
+                })}
+              </div>
+            </div>
+          </div>
+
+          <div className="accordion-item">
+            <h2 className="accordion-header">
+              <button
+                className="accordion-button"
+                type="button"
+                data-bs-toggle="collapse"
+                data-bs-target="#response"
+                aria-expanded="true"
+                aria-controls="response"
+              >
+                Response Body
+              </button>
+            </h2>
+            <div id="response" className="accordion-collapse collapse show">
+              <div className="accordion-body">
+                <CodeEditor initContent={preview.body} format={format} />
+              </div>
+            </div>
+          </div>
+
+          <div className="accordion-item">
+            <h2 className="accordion-header">
+              <button
+                className="accordion-button"
+                type="button"
+                data-bs-toggle="collapse"
+                data-bs-target="#response-headers"
+                aria-expanded="true"
+                aria-controls="response-headers"
+              >
+                Response Headers
+              </button>
+            </h2>
+            <div id="response-headers" className="accordion-collapse collapse">
+              <div className="accordion-body">
+                {map(preview.response_headers, (value, key) => {
+                  return (
+                    <p key={key}>
+                      {key}: {value}
+                    </p>
+                  );
+                })}
+              </div>
+            </div>
+          </div>
+        </div>
+      </>
+    );
+  };
+
+  const apiRecordView = () => {
+    return (
+      <>
+        <div className="card p-4 mt-4">
+          <strong className="mb-4">API Response</strong>
+          <CodeEditor initContent={preview.body} format="JSON" />
+        </div>
+      </>
+    );
+  };
+
+  return (
+    <>
+      {loading && (
+        <div className="d-flex justify-content-center">
+          <div className="spinner-border text-primary" role="status">
+            <span className="visually-hidden">Loading...</span>
+          </div>
+        </div>
+      )}
+      {!loading && view == "accordion" && preview && accordionView()}
+      {!loading && view == "apiRecord" && preview && apiRecordView()}
+    </>
+  );
+};
+
+export default PreviewPanel;

--- a/app/frontend/js/features/ExtractionApp/RequestsSlice.js
+++ b/app/frontend/js/features/ExtractionApp/RequestsSlice.js
@@ -19,6 +19,7 @@ export const previewRequest = createAsyncThunk(
       harvestDefinitionId,
       extractionDefinitionId,
       previousRequestId,
+      pipelineJobId,
       page,
       record,
     } = payload;
@@ -27,6 +28,10 @@ export const previewRequest = createAsyncThunk(
 
     if (previousRequestId != undefined) {
       path = `${path}&previous_request_id=${previousRequestId}`;
+    }
+
+    if (pipelineJobId != undefined && pipelineJobId != null) {
+      path = `${path}&pipeline_job_id=${pipelineJobId}`;
     }
 
     const response = request.get(path).then((response) => {

--- a/app/models/pipeline_job.rb
+++ b/app/models/pipeline_job.rb
@@ -43,10 +43,6 @@ class PipelineJob < ApplicationRecord
   # Step the processing chain forward once a block has finished. Creates the
   # next block's HarvestJob and enqueues it; when the chain is exhausted it falls
   # through to the enrichment jobs (preserving the legacy end-of-harvest behaviour).
-  #
-  # The existence guard makes this idempotent: the transformation-completion gate
-  # that triggers this can, under concurrent workers, fire more than once for a
-  # single block, and we must never create duplicate HarvestJobs for the next block.
   def advance_to_next_block(completed_definition)
     reload
     return if cancelled?
@@ -54,10 +50,8 @@ class PipelineJob < ApplicationRecord
     next_definition = pipeline.next_block(completed_definition)
     return enqueue_enrichment_jobs(completed_definition.name) if next_definition.blank?
 
-    return if harvest_jobs.exists?(harvest_definition_id: next_definition.id)
-
-    job = HarvestJob.create(harvest_definition: next_definition, pipeline_job: self)
-    HarvestWorker.perform_async_with_priority(job_priority, job.id)
+    job = create_next_block_job(next_definition)
+    HarvestWorker.perform_async_with_priority(job_priority, job.id) if job.present?
   end
 
   def enqueue_enrichment_jobs(job_id)
@@ -83,6 +77,16 @@ class PipelineJob < ApplicationRecord
   end
 
   private
+
+  # The transformation-completion gate can fire more than once for a single
+  # block under concurrent workers. The unique index on
+  # (pipeline_job_id, harvest_definition_id) turns the losing caller's insert
+  # into RecordNotUnique instead of a duplicate job; it must enqueue nothing.
+  def create_next_block_job(next_definition)
+    HarvestJob.create!(harvest_definition: next_definition, pipeline_job: self)
+  rescue ActiveRecord::RecordNotUnique
+    nil
+  end
 
   def should_queue_enrichments?
     reload

--- a/app/supplejack/extraction/enrichment_execution.rb
+++ b/app/supplejack/extraction/enrichment_execution.rb
@@ -9,6 +9,7 @@ module Extraction
       @extraction_definition = extraction_job.extraction_definition
       @harvest_job = extraction_job.harvest_job
       @harvest_report = @harvest_job.harvest_report if @harvest_job.present?
+      @records_consumed = 0
     end
 
     def call
@@ -25,6 +26,7 @@ module Extraction
       @extraction_definition.page = page
       api_records = JSON.parse(api_document.body)['records']
       extract_and_save_enrichment_documents(api_records)
+      @records_consumed += api_records.size
     end
 
     def handle_enrichment_error(error)
@@ -80,9 +82,14 @@ module Extraction
     end
 
     def page_from_index(index)
-      # per_page is nil for non-paginated sources (e.g. a pre-processing block
-      # scraping HTML); page is 1 in that case, so the paging offset is 0.
-      per_page = @extraction_definition.per_page || 0
+      # Page numbers name the saved document files, so they must be unique
+      # across the whole job — a repeated page silently overwrites an earlier
+      # record. Sources without per_page (e.g. preprocess output spanning
+      # multiple documents) can't derive an offset from pagination, so they
+      # use a running count of records consumed instead.
+      per_page = @extraction_definition.per_page
+      return @records_consumed + index + 1 if per_page.nil?
+
       ((@extraction_definition.page - 1) * per_page) + (index + 1)
     end
   end

--- a/app/views/extraction_definitions/_create_edit_enrichment_modal.html.erb
+++ b/app/views/extraction_definitions/_create_edit_enrichment_modal.html.erb
@@ -120,7 +120,7 @@
 
             <div class="col-4">
               <%= form.label :destination_id, class: 'form-label' do %>
-              Preview harvested records from
+              Preview Data:
               <span
                   data-bs-toggle="tooltip"
                   data-bs-title="The location of the harvested records you wish to use in your preview when building your enrichment transformation"><i class="bi bi-question-circle" aria-label="helper text"></i>

--- a/app/views/transformation_definitions/_create_edit_modal.html.erb
+++ b/app/views/transformation_definitions/_create_edit_modal.html.erb
@@ -44,7 +44,7 @@
 
             <div class='col-4'>
               <%= form.label :extraction_job_id, class: 'form-label' do %>
-                Extracted Data
+                Preview Data:
 
                 <span
                   data-bs-toggle="tooltip"

--- a/db/migrate/20260730050957_add_unique_index_to_harvest_jobs_on_pipeline_job_and_harvest_definition.rb
+++ b/db/migrate/20260730050957_add_unique_index_to_harvest_jobs_on_pipeline_job_and_harvest_definition.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class AddUniqueIndexToHarvestJobsOnPipelineJobAndHarvestDefinition < ActiveRecord::Migration[8.0]
+  def up
+    # The enrichment-queueing guard has always been check-then-create, so
+    # production may hold duplicate (pipeline_job, harvest_definition) pairs.
+    # Keep the oldest row of each pair so the index can be created.
+    execute <<~SQL.squish
+      DELETE duplicate FROM harvest_jobs duplicate
+      INNER JOIN harvest_jobs original
+        ON duplicate.pipeline_job_id = original.pipeline_job_id
+        AND duplicate.harvest_definition_id = original.harvest_definition_id
+        AND duplicate.id > original.id
+    SQL
+
+    add_index :harvest_jobs, %i[pipeline_job_id harvest_definition_id],
+              unique: true,
+              name: 'index_harvest_jobs_on_pipeline_job_and_harvest_definition'
+  end
+
+  def down
+    remove_index :harvest_jobs, name: 'index_harvest_jobs_on_pipeline_job_and_harvest_definition'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_07_14_214935) do
+ActiveRecord::Schema[8.0].define(version: 2026_07_30_050957) do
   create_table "api_response_reports", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "automation_step_id", null: false
     t.string "status", default: "not_started", null: false
@@ -196,6 +196,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_07_14_214935) do
     t.integer "pipeline_job_id"
     t.integer "extraction_job_id"
     t.index ["harvest_definition_id"], name: "index_harvest_jobs_on_harvest_definition_id"
+    t.index ["pipeline_job_id", "harvest_definition_id"], name: "index_harvest_jobs_on_pipeline_job_and_harvest_definition", unique: true
     t.index ["status"], name: "index_harvest_jobs_on_status"
   end
 

--- a/spec/models/harvest_job_spec.rb
+++ b/spec/models/harvest_job_spec.rb
@@ -15,6 +15,16 @@ RSpec.describe HarvestJob do
     end
   end
 
+  describe 'uniqueness per pipeline job and harvest definition' do
+    it 'refuses a second harvest job for the same pipeline job and harvest definition' do
+      create(:harvest_job, harvest_definition:, pipeline_job:)
+
+      expect do
+        create(:harvest_job, harvest_definition:, pipeline_job:)
+      end.to raise_error(ActiveRecord::RecordNotUnique)
+    end
+  end
+
   describe '#execute_delete_previous_records' do
     let(:pipeline) { create(:pipeline, :figshare) }
     let(:harvest_definition) { pipeline.harvest }

--- a/spec/models/pipeline_job_spec.rb
+++ b/spec/models/pipeline_job_spec.rb
@@ -57,6 +57,20 @@ RSpec.describe PipelineJob do
       end.not_to(change { pipeline_job.harvest_jobs.where(harvest_definition: pre_one).count })
     end
 
+    it 'neither duplicates the job nor enqueues a worker when completion signals race' do
+      allow(HarvestWorker).to receive(:perform_async_with_priority)
+
+      # The winning racer's row is already committed; this losing call must
+      # hit the unique index and back off without enqueueing anything.
+      create(:harvest_job, pipeline_job:, harvest_definition: pre_one)
+
+      expect do
+        pipeline_job.advance_to_next_block(pre_zero)
+      end.not_to(change { pipeline_job.harvest_jobs.where(harvest_definition: pre_one).count })
+
+      expect(HarvestWorker).not_to have_received(:perform_async_with_priority)
+    end
+
     it 'falls through to enrichments when there is no next block' do
       expect(pipeline_job).to receive(:enqueue_enrichment_jobs).with(pre_one.name)
 

--- a/spec/requests/extraction_definitions_spec.rb
+++ b/spec/requests/extraction_definitions_spec.rb
@@ -60,6 +60,8 @@ RSpec.describe 'ExtractionDefinitions' do
 
         expect(response.body).to include 'Target Source ID'
         expect(response.body).not_to include 'Paginated'
+        expect(response.body).to include 'Preview Data:'
+        expect(response.body).not_to include 'Preview harvested records from'
       end
     end
   end

--- a/spec/requests/requests_spec.rb
+++ b/spec/requests/requests_spec.rb
@@ -142,5 +142,98 @@ RSpec.describe 'Requests' do
         expect(content_source_response).to have_key('items')
       end
     end
+
+    context 'when the extraction definition consumes pre-processed data' do
+      let!(:preceding_block) do
+        create(:harvest_definition, kind: 'preprocess', position: 0, pipeline:)
+      end
+      let(:extraction_definition) do
+        create(:extraction_definition, pipeline:, base_url: 'http://example.com/api')
+      end
+      let(:harvest_definition) do
+        create(:harvest_definition, kind: 'harvest', position: 1, extraction_definition:, pipeline:)
+      end
+      let!(:request_one) { create(:request, extraction_definition:) }
+      let(:pipeline_job)  { create(:pipeline_job, pipeline:) }
+
+      def write_output(job, records)
+        PreProcess::Output.new(job.id, 0).write_page(1, records)
+      end
+
+      before do
+        stub_request(:get, 'http://example.com/api')
+          .to_return(status: 200, body: { hello: 'world' }.to_json, headers: fake_json_headers)
+      end
+
+      after { FileUtils.rm_rf(Dir.glob("#{PreProcess::Output::FOLDER}/*")) }
+
+      it 'previews the extraction using a pre-processed input record and the URL response' do
+        write_output(pipeline_job, [{ 'id' => '123', 'title' => 'Record A' }])
+
+        get pipeline_harvest_definition_extraction_definition_request_path(
+          pipeline, harvest_definition, extraction_definition, request_one
+        )
+
+        expect(response).to have_http_status :ok
+        preview = response.parsed_body['preview']
+
+        expect(preview['total_records']).to eq 1
+        expect(preview['current_run_id']).to eq pipeline_job.id
+        expect(JSON.parse(preview['input']['body'])).to include('id' => '123', 'title' => 'Record A')
+        expect(JSON.parse(preview['response']['body'])).to eq('hello' => 'world')
+      end
+
+      it 'lists available runs most-recent-first and defaults to the latest' do
+        older = create(:pipeline_job, pipeline:, created_at: 2.days.ago)
+        write_output(older, [{ 'id' => 'old' }])
+        write_output(pipeline_job, [{ 'id' => 'new' }])
+
+        get pipeline_harvest_definition_extraction_definition_request_path(
+          pipeline, harvest_definition, extraction_definition, request_one
+        )
+
+        preview = response.parsed_body['preview']
+        expect(preview['runs'].map { |run| run['id'] }).to eq [pipeline_job.id, older.id]
+        expect(preview['current_run_id']).to eq pipeline_job.id
+      end
+
+      it 'previews the run named by pipeline_job_id' do
+        other = create(:pipeline_job, pipeline:)
+        write_output(other, [{ 'id' => 'other' }])
+        write_output(pipeline_job, [{ 'id' => 'main' }])
+
+        get pipeline_harvest_definition_extraction_definition_request_path(
+          pipeline, harvest_definition, extraction_definition, request_one
+        ), params: { pipeline_job_id: other.id }
+
+        preview = response.parsed_body['preview']
+        expect(preview['current_run_id']).to eq other.id
+        expect(JSON.parse(preview['input']['body'])).to include('id' => 'other')
+      end
+
+      it 'returns an empty preview when the preceding block has no output' do
+        get pipeline_harvest_definition_extraction_definition_request_path(
+          pipeline, harvest_definition, extraction_definition, request_one
+        )
+
+        preview = response.parsed_body['preview']
+        expect(preview['runs']).to eq []
+        expect(preview['total_records']).to eq 0
+        expect(preview['current_run_id']).to be_nil
+      end
+
+      it 'does not error when a page file on disk is corrupt' do
+        write_output(pipeline_job, [{ 'id' => '123' }])
+        page_path = "#{PreProcess::Output.folder(pipeline_job.id, 0)}/1/preprocess__000000001.json"
+        File.write(page_path, 'not json{')
+
+        get pipeline_harvest_definition_extraction_definition_request_path(
+          pipeline, harvest_definition, extraction_definition, request_one
+        )
+
+        expect(response).to have_http_status :ok
+        expect(response.parsed_body['preview']['total_records']).to eq 0
+      end
+    end
   end
 end

--- a/spec/requests/transformation_definitions_spec.rb
+++ b/spec/requests/transformation_definitions_spec.rb
@@ -82,17 +82,6 @@ RSpec.describe 'Transformation Definitions' do
   end
 
   describe '#show' do
-    it 'labels the preview-data dropdown "Preview Data:"' do
-      get pipeline_harvest_definition_transformation_definition_path(
-        pipeline, harvest_definition, transformation_definition
-      )
-
-      expect(response).to be_successful
-      expect(response.body).to include 'Preview Data:'
-    end
-  end
-
-  describe '#show' do
     let(:transformation_definition) { create(:transformation_definition, pipeline:, extraction_job:) }
 
     it 'shows the details for a transformation_definition' do
@@ -100,6 +89,15 @@ RSpec.describe 'Transformation Definitions' do
                                                                      transformation_definition)
 
       expect(response).to have_http_status :ok
+    end
+
+    it 'labels the preview-data dropdown "Preview Data:"' do
+      get pipeline_harvest_definition_transformation_definition_path(
+        pipeline, harvest_definition, transformation_definition
+      )
+
+      expect(response).to be_successful
+      expect(response.body).to include 'Preview Data:'
     end
   end
 

--- a/spec/requests/transformation_definitions_spec.rb
+++ b/spec/requests/transformation_definitions_spec.rb
@@ -82,6 +82,17 @@ RSpec.describe 'Transformation Definitions' do
   end
 
   describe '#show' do
+    it 'labels the preview-data dropdown "Preview Data:"' do
+      get pipeline_harvest_definition_transformation_definition_path(
+        pipeline, harvest_definition, transformation_definition
+      )
+
+      expect(response).to be_successful
+      expect(response.body).to include 'Preview Data:'
+    end
+  end
+
+  describe '#show' do
     let(:transformation_definition) { create(:transformation_definition, pipeline:, extraction_job:) }
 
     it 'shows the details for a transformation_definition' do

--- a/spec/sidekiq/load_worker_spec.rb
+++ b/spec/sidekiq/load_worker_spec.rb
@@ -84,7 +84,10 @@ RSpec.describe LoadWorker, type: :job do
     end
 
     context 'when the harvest job is cancelled' do
-      let(:cancelled_harvest_job) { create(:harvest_job, :cancelled, harvest_definition:, pipeline_job:) }
+      let(:cancelled_pipeline_job) { create(:pipeline_job, pipeline:, destination:) }
+      let(:cancelled_harvest_job) do
+        create(:harvest_job, :cancelled, harvest_definition:, pipeline_job: cancelled_pipeline_job)
+      end
       let!(:cancelled_harvest_report) do
         create(:harvest_report, harvest_job: cancelled_harvest_job, pipeline_job:)
       end

--- a/spec/supplejack/extraction/enrichment_execution_spec.rb
+++ b/spec/supplejack/extraction/enrichment_execution_spec.rb
@@ -136,5 +136,35 @@ RSpec.describe Extraction::EnrichmentExecution do
         described_class.new(extraction_job).call
       end
     end
+
+    context 'when the previous block output spans multiple documents' do
+      let(:pipeline)           { create(:pipeline) }
+      let(:destination)        { create(:destination) }
+      let(:pipeline_job)       { create(:pipeline_job, pipeline:, destination:) }
+      let(:definition)         { create(:harvest_definition, pipeline:, kind: :preprocess, position: 1) }
+      let(:harvest_job)        { create(:harvest_job, harvest_definition: definition, pipeline_job:) }
+      let(:extraction_def)     { create(:extraction_definition, :enrichment, destination:, per_page: nil) }
+      let!(:request)           { create(:request, extraction_definition: extraction_def) }
+      let(:extraction_job)     { create(:extraction_job, extraction_definition: extraction_def, harvest_job:) }
+
+      before do
+        output = PreProcess::Output.new(pipeline_job.id, 0)
+        output.write_page(1, [{ 'url' => '/a' }, { 'url' => '/b' }])
+        output.write_page(2, [{ 'url' => '/c' }, { 'url' => '/d' }, { 'url' => '/e' }])
+
+        stub_request(:get, extraction_def.base_url).to_return(status: 200, body: '{}')
+      end
+
+      after { FileUtils.rm_rf(PreProcess::Output.folder(pipeline_job.id, 0)) }
+
+      it 'saves every record under a unique page number across documents' do
+        described_class.new(extraction_job).call
+
+        extracted_files = Dir.glob("#{extraction_job.extraction_folder}/**/*.json")
+        pages = extracted_files.map { |file| File.basename(file, '.json').split('__').last.to_i }
+
+        expect(pages.sort).to eq [1, 2, 3, 4, 5]
+      end
+    end
   end
 end

--- a/spec/supplejack/extraction/execution_spec.rb
+++ b/spec/supplejack/extraction/execution_spec.rb
@@ -87,10 +87,16 @@ RSpec.describe Extraction::Execution do
         create(:harvest_job, extraction_job:, harvest_definition:, pipeline_job:)
       end
       let!(:harvest_report)                 { create(:harvest_report, pipeline_job:, harvest_job:) }
+      # A definition can only have one harvest job per pipeline job, so the
+      # sample harvest runs in its own pipeline job.
+      let(:sample_pipeline_job)             { create(:pipeline_job, pipeline:, destination:) }
       let!(:sample_harvest_job)             do
-        create(:harvest_job, extraction_job: sample_extraction_job, harvest_definition:, pipeline_job:)
+        create(:harvest_job, extraction_job: sample_extraction_job, harvest_definition:,
+                             pipeline_job: sample_pipeline_job)
       end
-      let!(:sample_harvest_report)          { create(:harvest_report, pipeline_job:, harvest_job: sample_harvest_job) }
+      let!(:sample_harvest_report)          do
+        create(:harvest_report, pipeline_job: sample_pipeline_job, harvest_job: sample_harvest_job)
+      end
       let(:request_one)                     { create(:request, :figshare_initial_request, extraction_definition:) }
       let(:request_two)                     { create(:request, :figshare_main_request, extraction_definition:) }
 

--- a/spec/supplejack/extraction/record_extraction_spec.rb
+++ b/spec/supplejack/extraction/record_extraction_spec.rb
@@ -139,10 +139,11 @@ RSpec.describe Extraction::RecordExtraction do
         other_pipeline = create(:pipeline, name: 'OtherTestPipeline')
         other_pipeline_job = create(:pipeline_job, pipeline: other_pipeline, automation_step: other_automation_step)
         other_harvest_definition = create(:harvest_definition, pipeline: other_pipeline, kind: "harvest")
+        second_harvest_definition = create(:harvest_definition, pipeline: other_pipeline, kind: "harvest")
         enrichment_definition = create(:harvest_definition, pipeline: other_pipeline, kind: "enrichment")
-        
+
         @harvest_job_one    = create(:harvest_job, pipeline_job: other_pipeline_job, harvest_definition: other_harvest_definition)
-        @harvest_job_two    = create(:harvest_job, pipeline_job: other_pipeline_job, harvest_definition: other_harvest_definition)
+        @harvest_job_two    = create(:harvest_job, pipeline_job: other_pipeline_job, harvest_definition: second_harvest_definition)
         @enrichment_job_one = create(:harvest_job, pipeline_job: other_pipeline_job, harvest_definition: enrichment_definition)
       end
 


### PR DESCRIPTION
Lets you preview an extraction in a block after a pre-processing block, so you can confirm the pipeline is wired correctly before running it.

<img width="1392" height="1461" alt="Screenshot 2026-07-24 at 3 40 43 PM" src="https://github.com/user-attachments/assets/e9a2b22e-5490-4972-b135-ff09d544f435" />
